### PR TITLE
client: add zerocopy support for receiving data

### DIFF
--- a/turn-client-proto/benches/sendrecv.rs
+++ b/turn-client-proto/benches/sendrecv.rs
@@ -243,7 +243,7 @@ fn bench_turn_client_sendrecv(c: &mut Criterion) {
                 ),
                 now
             ),
-            TurnRecvRet::PeerData { data: _, transport: TransportType::Udp, peer } if peer == test.peer_addr,
+            TurnRecvRet::PeerData(peer) if peer.transport == TransportType::Udp && peer.peer == test.peer_addr
         ));
         group.bench_with_input(
             BenchmarkId::new("Indication", size),
@@ -282,7 +282,7 @@ fn bench_turn_client_sendrecv(c: &mut Criterion) {
                 ),
                 now
             ),
-            TurnRecvRet::PeerData { data: _, transport: TransportType::Udp, peer } if peer == test.peer_addr,
+            TurnRecvRet::PeerData(peer) if peer.transport == TransportType::Udp && peer.peer == test.peer_addr
         ));
         group.bench_with_input(
             BenchmarkId::new("Channel", size),

--- a/turn-client-proto/examples/turn.rs
+++ b/turn-client-proto/examples/turn.rs
@@ -131,17 +131,17 @@ impl TurnClientUdp {
                         inner_s.1.notify_one();
                         continue;
                     }
-                    TurnRecvRet::PeerData {
-                        data,
-                        transport,
-                        peer,
-                    } => {
+                    TurnRecvRet::PeerData(peer_data) => {
+                        let data = peer_data.data();
                         let len = data.len();
-                        let s = match String::from_utf8(data) {
-                            Ok(s) => s,
-                            Err(e) => format!("{:x?}", e.into_bytes()),
+                        let s = match std::str::from_utf8(data) {
+                            Ok(s) => s.to_string(),
+                            Err(_e) => format!("{:x?}", data),
                         };
-                        println!("received {len} bytes from {peer:?} using {transport:?}: '{s:?}'");
+                        println!(
+                            "received {len} bytes from {:?} using {:?}: {s:?}",
+                            peer_data.peer, peer_data.transport
+                        );
                         continue;
                     }
                 }
@@ -271,17 +271,17 @@ impl TurnClientTcp {
                         inner_s.1.notify_one();
                         continue;
                     }
-                    TurnRecvRet::PeerData {
-                        data,
-                        transport,
-                        peer,
-                    } => {
+                    TurnRecvRet::PeerData(peer_data) => {
+                        let data = peer_data.data();
                         let len = data.len();
-                        let s = match String::from_utf8(data) {
-                            Ok(s) => s,
-                            Err(e) => format!("{:x?}", e.into_bytes()),
+                        let s = match std::str::from_utf8(data) {
+                            Ok(s) => s.to_string(),
+                            Err(_e) => format!("{:x?}", data),
                         };
-                        println!("received {len} bytes from {peer:?} using {transport:?}: {s:?}",);
+                        println!(
+                            "received {len} bytes from {:?} using {:?}: {s:?}",
+                            peer_data.peer, peer_data.transport
+                        );
                         continue;
                     }
                 }


### PR DESCRIPTION
For UDP, there is now no copy of the received data. For TCP, the data still has to be buffered before it can be returned to the user.