### PR TITLE
ci: update coverage job versions

### DIFF
--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install cargo-tarpaulin
         uses: taiki-e/cache-cargo-install-action@v2
         with:
-          tool: cargo-tarpaulin@0.30
+          tool: cargo-tarpaulin@0.32
 
       - name: Run cargo-tarpaulin
         uses: actions-rs/cargo@v1
@@ -35,7 +35,7 @@ jobs:
           args: '--out Xml --lib --tests --doc -- --test-threads 1'
 
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v3.1.1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{secrets.CODECOV_TOKEN}}
 


### PR DESCRIPTION
- cargo tarpaulin to 0.32
- codecov action to v5