### PR TITLE
server: add support for ICMP handling

### DIFF
--- a/turn-server-proto/Cargo.toml
+++ b/turn-server-proto/Cargo.toml
@@ -21,6 +21,7 @@ stun-proto.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 turn-types = { path = "../turn-types", version = "0.3.0" }
+pnet_packet = "0.35"
 rand.workspace = true
 rustls = { workspace = true, optional = true }
 sans-io-time.workspace = true

--- a/turn-server-proto/src/api.rs
+++ b/turn-server-proto/src/api.rs
@@ -34,6 +34,15 @@ pub trait TurnServerApi: Send + std::fmt::Debug {
         transmit: Transmit<T>,
         now: Instant,
     ) -> Option<Transmit<Vec<u8>>>;
+    /// Provide a received ICMP packet to the [`TurnServerApi`].
+    ///
+    /// Any returned Transmit should be forwarded to the appropriate socket.
+    fn recv_icmp<T: AsRef<[u8]>>(
+        &mut self,
+        family: AddressFamily,
+        bytes: T,
+        now: Instant,
+    ) -> Option<Transmit<Vec<u8>>>;
     /// Poll the [`TurnServerApi`] in order to make further progress.
     ///
     /// The returned value indicates what the caller should do.


### PR DESCRIPTION
Received ICMP messages are sent back to the client that allocated the relayed address.

Part of RFC 8656