### PR TITLE
client/server: add support for openssl for (D)TLS backend

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,10 +28,21 @@ jobs:
     - name: Use MSRV Cargo.lock
       run: cp Cargo.lock.msrv Cargo.lock
       if: matrix.toolchain == '1.77'
+    # Install openssl through vcpkg from rust-openssl github CI
+    - run: echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
+      if: matrix.runs-on == 'windows-latest'
+    - run: vcpkg install openssl:x64-windows-static-md
+      if: matrix.runs-on == 'windows-latest'
     - name: Build
       run: cargo build --verbose
     - name: Build (without default features)
       run: cargo build --verbose --no-default-features
+    - name: Build with --features "std"
+      run: cargo build --verbose --no-default-features --features "std"
+    - name: Build with --features "openssl"
+      run: cargo build --verbose --no-default-features --features "openssl"
+    - name: Build with --features "rustls"
+      run: cargo build --verbose --no-default-features --features "rustls"
   test:
     strategy:
       matrix:
@@ -39,10 +50,13 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     steps:
     - uses: actions/checkout@v2
+    # Install openssl through vcpkg (from rust-openssl github CI)
+    - run: echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
+      if: matrix.runs-on == 'windows-latest'
+    - run: vcpkg install openssl:x64-windows-static-md
+      if: matrix.runs-on == 'windows-latest'
     - name: Run tests
-      run: cargo test --verbose
-    - name: Run tests (without default features)
-      run: cargo test --verbose --no-default-features
+      run: cargo test --verbose --all-features
   clippy:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ criterion = "0.7"
 rustls = "0.23"
 rustls-platform-verifier = "0.5"
 smallvec = "1"
+openssl = "0.10"
 
 [profile.bench]
 codegen-units = 16

--- a/turn-client-proto/Cargo.toml
+++ b/turn-client-proto/Cargo.toml
@@ -20,6 +20,7 @@ smallvec.workspace = true
 turn-types.workspace = true
 
 rustls = { workspace = true, optional = true }
+openssl = { workspace = true, optional = true }
 
 [dev-dependencies]
 tracing = { workspace = true, features = ["std"] }
@@ -33,9 +34,10 @@ rcgen = "0.14"
 sans-io-time = "0.1"
 
 [features]
-default = ["rustls", "std"]
+default = ["rustls", "std", "openssl"]
 std = ["thiserror/std", "turn-types/std"]
 rustls = ["dep:rustls", "std"]
+openssl = ["dep:openssl", "std"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin)'] }

--- a/turn-client-proto/src/client.rs
+++ b/turn-client-proto/src/client.rs
@@ -22,6 +22,8 @@ pub use crate::api::{
     TurnRecvRet,
 };
 use crate::api::{DelayedMessageOrChannelSend, TransmitBuild, TurnClientApi, TurnPeerData};
+#[cfg(feature = "openssl")]
+use crate::openssl::TurnClientOpensslTls;
 #[cfg(feature = "rustls")]
 use crate::rustls::TurnClientRustls;
 use crate::tcp::TurnClientTcp;
@@ -37,6 +39,9 @@ pub enum TurnClient {
     #[cfg(feature = "rustls")]
     /// A Rustls TURN client.
     Rustls(TurnClientRustls),
+    #[cfg(feature = "openssl")]
+    /// An Openssl TURN client.
+    Openssl(TurnClientOpensslTls),
 }
 
 impl TurnClientApi for TurnClient {
@@ -47,6 +52,8 @@ impl TurnClientApi for TurnClient {
             Self::Tcp(tcp) => tcp.transport(),
             #[cfg(feature = "rustls")]
             Self::Rustls(tcp) => tcp.transport(),
+            #[cfg(feature = "openssl")]
+            Self::Openssl(tcp) => tcp.transport(),
         }
     }
 
@@ -57,6 +64,8 @@ impl TurnClientApi for TurnClient {
             Self::Tcp(tcp) => tcp.local_addr(),
             #[cfg(feature = "rustls")]
             Self::Rustls(tcp) => tcp.local_addr(),
+            #[cfg(feature = "openssl")]
+            Self::Openssl(tcp) => tcp.local_addr(),
         }
     }
 
@@ -67,6 +76,8 @@ impl TurnClientApi for TurnClient {
             Self::Tcp(tcp) => tcp.remote_addr(),
             #[cfg(feature = "rustls")]
             Self::Rustls(tcp) => tcp.remote_addr(),
+            #[cfg(feature = "openssl")]
+            Self::Openssl(tcp) => tcp.remote_addr(),
         }
     }
 
@@ -77,6 +88,8 @@ impl TurnClientApi for TurnClient {
             Self::Tcp(tcp) => RelayedAddressesIter::Tcp(tcp.relayed_addresses()),
             #[cfg(feature = "rustls")]
             Self::Rustls(tcp) => RelayedAddressesIter::Rustls(tcp.relayed_addresses()),
+            #[cfg(feature = "openssl")]
+            Self::Openssl(tcp) => RelayedAddressesIter::Openssl(tcp.relayed_addresses()),
         }
     }
 
@@ -93,6 +106,10 @@ impl TurnClientApi for TurnClient {
             Self::Rustls(tcp) => {
                 PermissionAddressesIter::Rustls(tcp.permissions(transport, relayed))
             }
+            #[cfg(feature = "openssl")]
+            Self::Openssl(tcp) => {
+                PermissionAddressesIter::Openssl(tcp.permissions(transport, relayed))
+            }
         }
     }
 
@@ -103,6 +120,8 @@ impl TurnClientApi for TurnClient {
             Self::Tcp(tcp) => tcp.delete(now),
             #[cfg(feature = "rustls")]
             Self::Rustls(tcp) => tcp.delete(now),
+            #[cfg(feature = "openssl")]
+            Self::Openssl(tcp) => tcp.delete(now),
         }
     }
 
@@ -118,6 +137,8 @@ impl TurnClientApi for TurnClient {
             Self::Tcp(tcp) => tcp.create_permission(transport, peer_addr, now),
             #[cfg(feature = "rustls")]
             Self::Rustls(tcp) => tcp.create_permission(transport, peer_addr, now),
+            #[cfg(feature = "openssl")]
+            Self::Openssl(tcp) => tcp.create_permission(transport, peer_addr, now),
         }
     }
 
@@ -129,6 +150,8 @@ impl TurnClientApi for TurnClient {
             Self::Tcp(tcp) => tcp.have_permission(transport, to),
             #[cfg(feature = "rustls")]
             Self::Rustls(tcp) => tcp.have_permission(transport, to),
+            #[cfg(feature = "openssl")]
+            Self::Openssl(tcp) => tcp.have_permission(transport, to),
         }
     }
 
@@ -144,6 +167,8 @@ impl TurnClientApi for TurnClient {
             Self::Tcp(tcp) => tcp.bind_channel(transport, peer_addr, now),
             #[cfg(feature = "rustls")]
             Self::Rustls(tcp) => tcp.bind_channel(transport, peer_addr, now),
+            #[cfg(feature = "openssl")]
+            Self::Openssl(tcp) => tcp.bind_channel(transport, peer_addr, now),
         }
     }
 
@@ -164,6 +189,8 @@ impl TurnClientApi for TurnClient {
             Self::Tcp(tcp) => tcp.send_to(transport, to, data, now),
             #[cfg(feature = "rustls")]
             Self::Rustls(tcp) => tcp.send_to(transport, to, data, now),
+            #[cfg(feature = "openssl")]
+            Self::Openssl(tcp) => tcp.send_to(transport, to, data, now),
         }
     }
 
@@ -180,6 +207,8 @@ impl TurnClientApi for TurnClient {
             Self::Tcp(tcp) => tcp.recv(transmit, now),
             #[cfg(feature = "rustls")]
             Self::Rustls(tcp) => tcp.recv(transmit, now),
+            #[cfg(feature = "openssl")]
+            Self::Openssl(tcp) => tcp.recv(transmit, now),
         }
     }
 
@@ -190,6 +219,8 @@ impl TurnClientApi for TurnClient {
             Self::Tcp(tcp) => tcp.poll_recv(now),
             #[cfg(feature = "rustls")]
             Self::Rustls(tcp) => tcp.poll_recv(now),
+            #[cfg(feature = "openssl")]
+            Self::Openssl(tcp) => tcp.poll_recv(now),
         }
     }
 
@@ -200,6 +231,8 @@ impl TurnClientApi for TurnClient {
             Self::Tcp(tcp) => tcp.poll(now),
             #[cfg(feature = "rustls")]
             Self::Rustls(tcp) => tcp.poll(now),
+            #[cfg(feature = "openssl")]
+            Self::Openssl(tcp) => tcp.poll(now),
         }
     }
 
@@ -210,6 +243,8 @@ impl TurnClientApi for TurnClient {
             Self::Tcp(tcp) => tcp.poll_transmit(now),
             #[cfg(feature = "rustls")]
             Self::Rustls(tcp) => tcp.poll_transmit(now),
+            #[cfg(feature = "openssl")]
+            Self::Openssl(tcp) => tcp.poll_transmit(now),
         }
     }
 
@@ -220,6 +255,8 @@ impl TurnClientApi for TurnClient {
             Self::Tcp(tcp) => tcp.poll_event(),
             #[cfg(feature = "rustls")]
             Self::Rustls(tcp) => tcp.poll_event(),
+            #[cfg(feature = "openssl")]
+            Self::Openssl(tcp) => tcp.poll_event(),
         }
     }
 }
@@ -242,7 +279,24 @@ macro_rules! impl_iterator {
     }
 }
 
-#[cfg(feature = "rustls")]
+#[cfg(all(feature = "rustls", feature = "openssl"))]
+impl_iterator!(
+    RelayedAddressesIter,
+    (TransportType, SocketAddr),
+    Udp,
+    Tcp,
+    Rustls,
+    Openssl
+);
+#[cfg(all(not(feature = "rustls"), feature = "openssl"))]
+impl_iterator!(
+    RelayedAddressesIter,
+    (TransportType, SocketAddr),
+    Udp,
+    Tcp,
+    Openssl
+);
+#[cfg(all(feature = "rustls", not(feature = "openssl")))]
 impl_iterator!(
     RelayedAddressesIter,
     (TransportType, SocketAddr),
@@ -250,12 +304,16 @@ impl_iterator!(
     Tcp,
     Rustls
 );
-#[cfg(not(feature = "rustls"))]
+#[cfg(all(not(feature = "rustls"), not(feature = "openssl")))]
 impl_iterator!(RelayedAddressesIter, (TransportType, SocketAddr), Udp, Tcp);
 
-#[cfg(feature = "rustls")]
+#[cfg(all(feature = "rustls", feature = "openssl"))]
+impl_iterator!(PermissionAddressesIter, IpAddr, Udp, Tcp, Rustls, Openssl);
+#[cfg(all(feature = "rustls", not(feature = "openssl")))]
 impl_iterator!(PermissionAddressesIter, IpAddr, Udp, Tcp, Rustls);
-#[cfg(not(feature = "rustls"))]
+#[cfg(all(not(feature = "rustls"), feature = "openssl"))]
+impl_iterator!(PermissionAddressesIter, IpAddr, Udp, Tcp, Openssl);
+#[cfg(all(not(feature = "rustls"), not(feature = "openssl")))]
 impl_iterator!(PermissionAddressesIter, IpAddr, Udp, Tcp);
 
 impl From<TurnClientUdp> for TurnClient {
@@ -274,5 +332,12 @@ impl From<TurnClientTcp> for TurnClient {
 impl From<TurnClientRustls> for TurnClient {
     fn from(value: TurnClientRustls) -> Self {
         Self::Rustls(value)
+    }
+}
+
+#[cfg(feature = "openssl")]
+impl From<TurnClientOpensslTls> for TurnClient {
+    fn from(value: TurnClientOpensslTls) -> Self {
+        Self::Openssl(value)
     }
 }

--- a/turn-client-proto/src/client.rs
+++ b/turn-client-proto/src/client.rs
@@ -23,7 +23,7 @@ pub use crate::api::{
 };
 use crate::api::{DelayedMessageOrChannelSend, TransmitBuild, TurnClientApi, TurnPeerData};
 #[cfg(feature = "rustls")]
-use crate::rustls::TurnClientTls;
+use crate::rustls::TurnClientRustls;
 use crate::tcp::TurnClientTcp;
 use crate::udp::TurnClientUdp;
 
@@ -35,8 +35,8 @@ pub enum TurnClient {
     /// A TCP TURN client.
     Tcp(TurnClientTcp),
     #[cfg(feature = "rustls")]
-    /// A TLS TURN client.
-    Tls(TurnClientTls),
+    /// A Rustls TURN client.
+    Rustls(TurnClientRustls),
 }
 
 impl TurnClientApi for TurnClient {
@@ -46,7 +46,7 @@ impl TurnClientApi for TurnClient {
             Self::Udp(udp) => udp.transport(),
             Self::Tcp(tcp) => tcp.transport(),
             #[cfg(feature = "rustls")]
-            Self::Tls(tcp) => tcp.transport(),
+            Self::Rustls(tcp) => tcp.transport(),
         }
     }
 
@@ -56,7 +56,7 @@ impl TurnClientApi for TurnClient {
             Self::Udp(udp) => udp.local_addr(),
             Self::Tcp(tcp) => tcp.local_addr(),
             #[cfg(feature = "rustls")]
-            Self::Tls(tcp) => tcp.local_addr(),
+            Self::Rustls(tcp) => tcp.local_addr(),
         }
     }
 
@@ -66,7 +66,7 @@ impl TurnClientApi for TurnClient {
             Self::Udp(udp) => udp.remote_addr(),
             Self::Tcp(tcp) => tcp.remote_addr(),
             #[cfg(feature = "rustls")]
-            Self::Tls(tcp) => tcp.remote_addr(),
+            Self::Rustls(tcp) => tcp.remote_addr(),
         }
     }
 
@@ -76,7 +76,7 @@ impl TurnClientApi for TurnClient {
             Self::Udp(udp) => RelayedAddressesIter::Udp(udp.relayed_addresses()),
             Self::Tcp(tcp) => RelayedAddressesIter::Tcp(tcp.relayed_addresses()),
             #[cfg(feature = "rustls")]
-            Self::Tls(tcp) => RelayedAddressesIter::Tls(tcp.relayed_addresses()),
+            Self::Rustls(tcp) => RelayedAddressesIter::Rustls(tcp.relayed_addresses()),
         }
     }
 
@@ -90,7 +90,9 @@ impl TurnClientApi for TurnClient {
             Self::Udp(udp) => PermissionAddressesIter::Udp(udp.permissions(transport, relayed)),
             Self::Tcp(tcp) => PermissionAddressesIter::Tcp(tcp.permissions(transport, relayed)),
             #[cfg(feature = "rustls")]
-            Self::Tls(tcp) => PermissionAddressesIter::Tls(tcp.permissions(transport, relayed)),
+            Self::Rustls(tcp) => {
+                PermissionAddressesIter::Rustls(tcp.permissions(transport, relayed))
+            }
         }
     }
 
@@ -100,7 +102,7 @@ impl TurnClientApi for TurnClient {
             Self::Udp(udp) => udp.delete(now),
             Self::Tcp(tcp) => tcp.delete(now),
             #[cfg(feature = "rustls")]
-            Self::Tls(tcp) => tcp.delete(now),
+            Self::Rustls(tcp) => tcp.delete(now),
         }
     }
 
@@ -115,7 +117,7 @@ impl TurnClientApi for TurnClient {
             Self::Udp(udp) => udp.create_permission(transport, peer_addr, now),
             Self::Tcp(tcp) => tcp.create_permission(transport, peer_addr, now),
             #[cfg(feature = "rustls")]
-            Self::Tls(tcp) => tcp.create_permission(transport, peer_addr, now),
+            Self::Rustls(tcp) => tcp.create_permission(transport, peer_addr, now),
         }
     }
 
@@ -126,7 +128,7 @@ impl TurnClientApi for TurnClient {
             Self::Udp(udp) => udp.have_permission(transport, to),
             Self::Tcp(tcp) => tcp.have_permission(transport, to),
             #[cfg(feature = "rustls")]
-            Self::Tls(tcp) => tcp.have_permission(transport, to),
+            Self::Rustls(tcp) => tcp.have_permission(transport, to),
         }
     }
 
@@ -141,7 +143,7 @@ impl TurnClientApi for TurnClient {
             Self::Udp(udp) => udp.bind_channel(transport, peer_addr, now),
             Self::Tcp(tcp) => tcp.bind_channel(transport, peer_addr, now),
             #[cfg(feature = "rustls")]
-            Self::Tls(tcp) => tcp.bind_channel(transport, peer_addr, now),
+            Self::Rustls(tcp) => tcp.bind_channel(transport, peer_addr, now),
         }
     }
 
@@ -161,7 +163,7 @@ impl TurnClientApi for TurnClient {
             Self::Udp(udp) => udp.send_to(transport, to, data, now),
             Self::Tcp(tcp) => tcp.send_to(transport, to, data, now),
             #[cfg(feature = "rustls")]
-            Self::Tls(tcp) => tcp.send_to(transport, to, data, now),
+            Self::Rustls(tcp) => tcp.send_to(transport, to, data, now),
         }
     }
 
@@ -177,7 +179,7 @@ impl TurnClientApi for TurnClient {
             Self::Udp(udp) => udp.recv(transmit, now),
             Self::Tcp(tcp) => tcp.recv(transmit, now),
             #[cfg(feature = "rustls")]
-            Self::Tls(tcp) => tcp.recv(transmit, now),
+            Self::Rustls(tcp) => tcp.recv(transmit, now),
         }
     }
 
@@ -187,7 +189,7 @@ impl TurnClientApi for TurnClient {
             Self::Udp(udp) => udp.poll_recv(now),
             Self::Tcp(tcp) => tcp.poll_recv(now),
             #[cfg(feature = "rustls")]
-            Self::Tls(tcp) => tcp.poll_recv(now),
+            Self::Rustls(tcp) => tcp.poll_recv(now),
         }
     }
 
@@ -197,7 +199,7 @@ impl TurnClientApi for TurnClient {
             Self::Udp(udp) => udp.poll(now),
             Self::Tcp(tcp) => tcp.poll(now),
             #[cfg(feature = "rustls")]
-            Self::Tls(tcp) => tcp.poll(now),
+            Self::Rustls(tcp) => tcp.poll(now),
         }
     }
 
@@ -207,7 +209,7 @@ impl TurnClientApi for TurnClient {
             Self::Udp(udp) => udp.poll_transmit(now),
             Self::Tcp(tcp) => tcp.poll_transmit(now),
             #[cfg(feature = "rustls")]
-            Self::Tls(tcp) => tcp.poll_transmit(now),
+            Self::Rustls(tcp) => tcp.poll_transmit(now),
         }
     }
 
@@ -217,7 +219,7 @@ impl TurnClientApi for TurnClient {
             Self::Udp(udp) => udp.poll_event(),
             Self::Tcp(tcp) => tcp.poll_event(),
             #[cfg(feature = "rustls")]
-            Self::Tls(tcp) => tcp.poll_event(),
+            Self::Rustls(tcp) => tcp.poll_event(),
         }
     }
 }
@@ -246,13 +248,13 @@ impl_iterator!(
     (TransportType, SocketAddr),
     Udp,
     Tcp,
-    Tls
+    Rustls
 );
 #[cfg(not(feature = "rustls"))]
 impl_iterator!(RelayedAddressesIter, (TransportType, SocketAddr), Udp, Tcp);
 
 #[cfg(feature = "rustls")]
-impl_iterator!(PermissionAddressesIter, IpAddr, Udp, Tcp, Tls);
+impl_iterator!(PermissionAddressesIter, IpAddr, Udp, Tcp, Rustls);
 #[cfg(not(feature = "rustls"))]
 impl_iterator!(PermissionAddressesIter, IpAddr, Udp, Tcp);
 
@@ -269,8 +271,8 @@ impl From<TurnClientTcp> for TurnClient {
 }
 
 #[cfg(feature = "rustls")]
-impl From<TurnClientTls> for TurnClient {
-    fn from(value: TurnClientTls) -> Self {
-        Self::Tls(value)
+impl From<TurnClientRustls> for TurnClient {
+    fn from(value: TurnClientRustls) -> Self {
+        Self::Rustls(value)
     }
 }

--- a/turn-client-proto/src/lib.rs
+++ b/turn-client-proto/src/lib.rs
@@ -59,6 +59,8 @@ mod protocol;
 pub mod tcp;
 pub mod udp;
 
+#[cfg(feature = "openssl")]
+pub mod openssl;
 #[cfg(feature = "rustls")]
 pub mod rustls;
 

--- a/turn-client-proto/src/openssl.rs
+++ b/turn-client-proto/src/openssl.rs
@@ -1,0 +1,836 @@
+// Copyright (C) 2025 Matthew Waters <matthew@centricular.com>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! TLS TURN client using OpenSSL.
+//!
+//! An implementation of a TURN client suitable for TLS over TCP connections and DTLS over UDP
+//! connections.
+
+use alloc::collections::VecDeque;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::net::{IpAddr, SocketAddr};
+use openssl::ssl::{HandshakeError, MidHandshakeSslStream, Ssl, SslContext, SslStream};
+use std::io::{Read, Write};
+
+use stun_proto::agent::{StunAgent, Transmit};
+use stun_proto::types::data::Data;
+use stun_proto::Instant;
+
+use stun_proto::types::TransportType;
+
+use turn_types::channel::ChannelData;
+use turn_types::AddressFamily;
+use turn_types::TurnCredentials;
+
+use tracing::{trace, warn};
+
+use crate::api::{
+    DataRangeOrOwned, DelayedMessageOrChannelSend, TransmitBuild, TurnClientApi, TurnPeerData,
+};
+use crate::protocol::{TurnClientProtocol, TurnProtocolChannelRecv, TurnProtocolRecv};
+
+pub use crate::api::{
+    BindChannelError, CreatePermissionError, DeleteError, SendError, TurnEvent, TurnPollRet,
+    TurnRecvRet,
+};
+use crate::tcp::ensure_data_owned;
+use turn_types::tcp::{IncomingTcp, StoredTcp, TurnTcpBuffer};
+
+/// A TURN client that communicates over TLS.
+#[derive(Debug)]
+pub struct TurnClientOpensslTls {
+    protocol: TurnClientProtocol,
+    incoming_tcp_buffer: TurnTcpBuffer,
+    handshake: HandshakeState,
+    closing: bool,
+}
+
+#[derive(Debug)]
+enum HandshakeState {
+    Init(Ssl, OsslBio),
+    Handshaking(MidHandshakeSslStream<OsslBio>),
+    Done(SslStream<OsslBio>),
+    Nothing,
+}
+
+impl HandshakeState {
+    fn complete(&mut self) -> Result<&mut SslStream<OsslBio>, std::io::Error> {
+        if let Self::Done(s) = self {
+            return Ok(s);
+        }
+        let taken = core::mem::replace(self, Self::Nothing);
+
+        let ret = match taken {
+            Self::Init(ssl, bio) => ssl.connect(bio),
+            Self::Handshaking(mid) => mid.handshake(),
+            Self::Done(_) | Self::Nothing => unreachable!(),
+        };
+
+        match ret {
+            Ok(s) => {
+                *self = Self::Done(s);
+                Ok(self.complete()?)
+            }
+            Err(HandshakeError::WouldBlock(mid)) => {
+                *self = Self::Handshaking(mid);
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::WouldBlock,
+                    "Would Block",
+                ))
+            }
+            Err(HandshakeError::SetupFailure(e)) => Err(std::io::Error::new(
+                std::io::ErrorKind::ConnectionRefused,
+                e,
+            )),
+            Err(HandshakeError::Failure(mid)) => {
+                *self = Self::Handshaking(mid);
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::WouldBlock,
+                    "Would Block",
+                ))
+            }
+        }
+    }
+    fn inner_mut(&mut self) -> &mut OsslBio {
+        match self {
+            Self::Init(_ssl, stream) => stream,
+            Self::Handshaking(mid) => mid.get_mut(),
+            Self::Done(stream) => stream.get_mut(),
+            Self::Nothing => unreachable!(),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct OsslBio {
+    incoming: Vec<u8>,
+    outgoing: VecDeque<Vec<u8>>,
+}
+
+impl OsslBio {
+    fn push_incoming(&mut self, buf: &[u8]) {
+        self.incoming.extend_from_slice(buf)
+    }
+
+    fn pop_outgoing(&mut self) -> Option<Vec<u8>> {
+        self.outgoing.pop_front()
+    }
+}
+
+impl std::io::Write for OsslBio {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.outgoing.push_back(buf.to_vec());
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl std::io::Read for OsslBio {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let len = self.incoming.len();
+        let max = buf.len().min(len);
+
+        if len == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::WouldBlock,
+                "Would Block",
+            ));
+        }
+
+        buf[..max].copy_from_slice(&self.incoming[..max]);
+        if max == len {
+            self.incoming.truncate(0);
+        } else {
+            self.incoming.drain(..max);
+        }
+
+        Ok(max)
+    }
+}
+
+impl TurnClientOpensslTls {
+    /// Allocate an address on a TURN server to relay data to and from peers.
+    pub fn allocate(
+        transport: TransportType,
+        local_addr: SocketAddr,
+        remote_addr: SocketAddr,
+        credentials: TurnCredentials,
+        allocation_families: &[AddressFamily],
+        ssl_context: SslContext,
+    ) -> Self {
+        let ssl = Ssl::new(&ssl_context).expect("Cannot create ssl structure");
+
+        let stun_agent = StunAgent::builder(transport, local_addr)
+            .remote_addr(remote_addr)
+            .build();
+        Self {
+            protocol: TurnClientProtocol::new(stun_agent, credentials, allocation_families),
+            incoming_tcp_buffer: TurnTcpBuffer::new(),
+            handshake: HandshakeState::Init(ssl, OsslBio::default()),
+            closing: false,
+        }
+    }
+
+    fn handle_incoming_plaintext<T: AsRef<[u8]> + core::fmt::Debug>(
+        &mut self,
+        transmit: Transmit<Vec<u8>>,
+        now: Instant,
+    ) -> TurnRecvRet<T> {
+        match self.incoming_tcp_buffer.incoming_tcp(transmit) {
+            None => TurnRecvRet::Handled,
+            Some(IncomingTcp::CompleteMessage(transmit, msg_range)) => {
+                match self.protocol.handle_message(
+                    &transmit.data.as_slice()[msg_range.start..msg_range.end],
+                    now,
+                ) {
+                    TurnProtocolRecv::Handled => TurnRecvRet::Handled,
+                    // XXX: this might be grounds for connection termination.
+                    TurnProtocolRecv::Ignored(_) => TurnRecvRet::Handled,
+                    TurnProtocolRecv::PeerData {
+                        data: _,
+                        range,
+                        transport,
+                        peer,
+                    } => TurnRecvRet::PeerData(TurnPeerData {
+                        data: DataRangeOrOwned::Owned(ensure_data_owned(transmit.data, range)),
+                        transport,
+                        peer,
+                    }),
+                }
+            }
+            Some(IncomingTcp::CompleteChannel(transmit, msg_range)) => {
+                let channel =
+                    ChannelData::parse(&transmit.data.as_slice()[msg_range.start..msg_range.end])
+                        .unwrap();
+                match self.protocol.handle_channel(channel, now) {
+                    TurnProtocolChannelRecv::Ignored => TurnRecvRet::Handled,
+                    TurnProtocolChannelRecv::PeerData {
+                        range,
+                        transport,
+                        peer,
+                    } => TurnRecvRet::PeerData(TurnPeerData {
+                        data: DataRangeOrOwned::Owned(ensure_data_owned(transmit.data, range)),
+                        transport,
+                        peer,
+                    }),
+                }
+            }
+            Some(IncomingTcp::StoredMessage(data, transmit)) => {
+                match self.protocol.handle_message(data, now) {
+                    TurnProtocolRecv::Handled => TurnRecvRet::Handled,
+                    TurnProtocolRecv::Ignored(_) => TurnRecvRet::Handled,
+                    TurnProtocolRecv::PeerData {
+                        data: _,
+                        range,
+                        transport,
+                        peer,
+                    } => TurnRecvRet::PeerData(TurnPeerData {
+                        data: DataRangeOrOwned::Owned(ensure_data_owned(transmit.data, range)),
+                        transport,
+                        peer,
+                    }),
+                }
+            }
+            Some(IncomingTcp::StoredChannel(data, transmit)) => {
+                let channel = ChannelData::parse(&data).unwrap();
+                match self.protocol.handle_channel(channel, now) {
+                    TurnProtocolChannelRecv::Ignored => TurnRecvRet::Handled,
+                    TurnProtocolChannelRecv::PeerData {
+                        range,
+                        transport,
+                        peer,
+                    } => TurnRecvRet::PeerData(TurnPeerData {
+                        data: DataRangeOrOwned::Owned(
+                            transmit.data[range.start..range.end].to_vec(),
+                        ),
+                        transport,
+                        peer,
+                    }),
+                }
+            }
+        }
+    }
+}
+
+impl TurnClientApi for TurnClientOpensslTls {
+    fn transport(&self) -> TransportType {
+        self.protocol.transport()
+    }
+
+    fn local_addr(&self) -> SocketAddr {
+        self.protocol.local_addr()
+    }
+
+    fn remote_addr(&self) -> SocketAddr {
+        self.protocol.remote_addr()
+    }
+
+    fn poll(&mut self, now: Instant) -> TurnPollRet {
+        let protocol_ret = self.protocol.poll(now);
+        if !self.handshake.inner_mut().outgoing.is_empty() {
+            return TurnPollRet::WaitUntil(now);
+        }
+        protocol_ret
+    }
+
+    fn relayed_addresses(&self) -> impl Iterator<Item = (TransportType, SocketAddr)> + '_ {
+        self.protocol.relayed_addresses()
+    }
+
+    fn permissions(
+        &self,
+        transport: TransportType,
+        relayed: SocketAddr,
+    ) -> impl Iterator<Item = IpAddr> + '_ {
+        self.protocol.permissions(transport, relayed)
+    }
+
+    fn poll_transmit(&mut self, now: Instant) -> Option<Transmit<Data<'static>>> {
+        if let Some(outgoing) = self.handshake.inner_mut().pop_outgoing() {
+            return Some(Transmit::new(
+                outgoing.into_boxed_slice().into(),
+                self.transport(),
+                self.local_addr(),
+                self.remote_addr(),
+            ));
+        }
+
+        let Ok(stream) = self.handshake.complete() else {
+            return None;
+        };
+
+        while let Some(transmit) = self.protocol.poll_transmit(now) {
+            stream.write_all(&transmit.data).unwrap();
+        }
+
+        self.handshake.inner_mut().pop_outgoing().map(|outgoing| {
+            Transmit::new(
+                outgoing.into_boxed_slice().into(),
+                self.transport(),
+                self.local_addr(),
+                self.remote_addr(),
+            )
+        })
+    }
+
+    fn poll_event(&mut self) -> Option<TurnEvent> {
+        self.protocol.poll_event()
+    }
+
+    fn delete(&mut self, now: Instant) -> Result<(), DeleteError> {
+        self.protocol.delete(now)?;
+        self.closing = true;
+        let stream = self.handshake.complete().expect("handshake not completed");
+
+        while let Some(transmit) = self.protocol.poll_transmit(now) {
+            stream.write_all(&transmit.data).unwrap();
+        }
+        stream.shutdown().unwrap();
+        Ok(())
+    }
+
+    fn create_permission(
+        &mut self,
+        transport: TransportType,
+        peer_addr: IpAddr,
+        now: Instant,
+    ) -> Result<(), CreatePermissionError> {
+        self.protocol.create_permission(transport, peer_addr, now)?;
+        let stream = self.handshake.complete().expect("handshake not completed");
+
+        while let Some(transmit) = self.protocol.poll_transmit(now) {
+            stream.write_all(&transmit.data).unwrap();
+        }
+
+        Ok(())
+    }
+
+    fn have_permission(&self, transport: TransportType, to: IpAddr) -> bool {
+        self.protocol.have_permission(transport, to)
+    }
+
+    fn bind_channel(
+        &mut self,
+        transport: TransportType,
+        peer_addr: SocketAddr,
+        now: Instant,
+    ) -> Result<(), BindChannelError> {
+        self.protocol.bind_channel(transport, peer_addr, now)?;
+        let stream = self.handshake.complete().expect("handshake not completed");
+
+        while let Some(transmit) = self.protocol.poll_transmit(now) {
+            stream.write_all(&transmit.data).unwrap();
+        }
+
+        Ok(())
+    }
+
+    fn send_to<T: AsRef<[u8]> + core::fmt::Debug>(
+        &mut self,
+        transport: TransportType,
+        to: SocketAddr,
+        data: T,
+        now: Instant,
+    ) -> Result<Option<TransmitBuild<DelayedMessageOrChannelSend<T>>>, SendError> {
+        let stream = match self.handshake.complete() {
+            Ok(stream) => stream,
+            Err(_) => return Err(SendError::NoAllocation),
+        };
+        let transmit = self.protocol.send_to(transport, to, data, now)?;
+        let transmit = transmit.build();
+        if let Err(e) = stream.write_all(&transmit.data) {
+            self.protocol.error();
+            warn!("Error when writing plaintext: {e:?}");
+            return Err(SendError::NoAllocation);
+        }
+
+        if let Some(outgoing) = stream.get_mut().pop_outgoing() {
+            return Ok(Some(TransmitBuild::new(
+                DelayedMessageOrChannelSend::Data(outgoing),
+                self.transport(),
+                self.local_addr(),
+                self.remote_addr(),
+            )));
+        }
+
+        Ok(None)
+    }
+
+    #[tracing::instrument(
+        name = "turn_openssl_recv",
+        skip(self, transmit, now),
+        fields(
+            transport = %transmit.transport,
+            from = ?transmit.from,
+            data_len = transmit.data.as_ref().len()
+        )
+    )]
+    fn recv<T: AsRef<[u8]> + core::fmt::Debug>(
+        &mut self,
+        transmit: Transmit<T>,
+        now: Instant,
+    ) -> TurnRecvRet<T> {
+        /* is this data for our client? */
+        if transmit.to != self.local_addr()
+            || self.transport() != transmit.transport
+            || transmit.from != self.remote_addr()
+        {
+            trace!(
+                "received data not directed at us ({:?}) but for {:?}!",
+                self.local_addr(),
+                transmit.to
+            );
+            return TurnRecvRet::Ignored(transmit);
+        }
+
+        self.handshake
+            .inner_mut()
+            .push_incoming(transmit.data.as_ref());
+
+        let stream = match self.handshake.complete() {
+            Ok(stream) => stream,
+            Err(e) => {
+                if e.kind() == std::io::ErrorKind::WouldBlock {
+                    return TurnRecvRet::Handled;
+                }
+                return TurnRecvRet::Ignored(transmit);
+            }
+        };
+
+        let mut out = vec![0; 2048];
+        let len = match stream.read(&mut out) {
+            Ok(len) => len,
+            Err(e) => {
+                if e.kind() != std::io::ErrorKind::WouldBlock {
+                    self.protocol.error();
+                    tracing::warn!("Error: {}", e);
+                }
+                return TurnRecvRet::Ignored(transmit);
+            }
+        };
+        out.resize(len, 0);
+
+        let transmit = Transmit::new(out, transmit.transport, transmit.from, transmit.to);
+
+        self.handle_incoming_plaintext(transmit, now)
+    }
+
+    fn poll_recv(&mut self, now: Instant) -> Option<TurnPeerData<Vec<u8>>> {
+        while let Some(recv) = self.incoming_tcp_buffer.poll_recv() {
+            match recv {
+                StoredTcp::Message(msg) => {
+                    if let TurnProtocolRecv::PeerData {
+                        data,
+                        range,
+                        transport,
+                        peer,
+                    } = self.protocol.handle_message(msg, now)
+                    {
+                        return Some(TurnPeerData {
+                            data: DataRangeOrOwned::Range { data, range },
+                            transport,
+                            peer,
+                        });
+                    }
+                }
+                StoredTcp::Channel(data) => {
+                    let Ok(channel) = ChannelData::parse(&data) else {
+                        continue;
+                    };
+                    if let TurnProtocolChannelRecv::PeerData {
+                        range,
+                        transport,
+                        peer,
+                    } = self.protocol.handle_channel(channel, now)
+                    {
+                        return Some(TurnPeerData {
+                            data: DataRangeOrOwned::Range { data, range },
+                            transport,
+                            peer,
+                        });
+                    }
+                }
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::borrow::ToOwned;
+    use alloc::string::{String, ToString};
+    use core::time::Duration;
+    use openssl::ssl::SslMethod;
+
+    use crate::api::tests::{transmit_send_build, TurnTest};
+    use crate::client::TurnClient;
+    use turn_types::message::CREATE_PERMISSION;
+    use turn_types::stun::message::{Message, MessageType, MessageWriteVec, TransactionId};
+    use turn_types::stun::prelude::MessageWrite;
+
+    use super::*;
+
+    use rcgen::CertifiedKey;
+    use rustls::crypto::aws_lc_rs as crypto_provider;
+    use rustls::pki_types::PrivateKeyDer;
+    use rustls::ServerConfig;
+    use turn_server_proto::api::TurnServerApi;
+    use turn_server_proto::rustls::RustlsTurnServer;
+    mod danger {
+        use rustls::client::danger::HandshakeSignatureValid;
+        use rustls::crypto::{verify_tls12_signature, verify_tls13_signature, CryptoProvider};
+        use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+        use rustls::DigitallySignedStruct;
+
+        use alloc::vec::Vec;
+
+        #[derive(Debug)]
+        pub struct NoCertificateVerification(CryptoProvider);
+
+        impl NoCertificateVerification {
+            pub fn new(provider: CryptoProvider) -> Self {
+                Self(provider)
+            }
+        }
+
+        impl rustls::client::danger::ServerCertVerifier for NoCertificateVerification {
+            fn verify_server_cert(
+                &self,
+                _end_entity: &CertificateDer<'_>,
+                _intermediates: &[CertificateDer<'_>],
+                _server_name: &ServerName<'_>,
+                _ocsp: &[u8],
+                _now: UnixTime,
+            ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+                Ok(rustls::client::danger::ServerCertVerified::assertion())
+            }
+
+            fn verify_tls12_signature(
+                &self,
+                message: &[u8],
+                cert: &CertificateDer<'_>,
+                dss: &DigitallySignedStruct,
+            ) -> Result<HandshakeSignatureValid, rustls::Error> {
+                verify_tls12_signature(
+                    message,
+                    cert,
+                    dss,
+                    &self.0.signature_verification_algorithms,
+                )
+            }
+
+            fn verify_tls13_signature(
+                &self,
+                message: &[u8],
+                cert: &CertificateDer<'_>,
+                dss: &DigitallySignedStruct,
+            ) -> Result<HandshakeSignatureValid, rustls::Error> {
+                verify_tls13_signature(
+                    message,
+                    cert,
+                    dss,
+                    &self.0.signature_verification_algorithms,
+                )
+            }
+
+            fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+                self.0.signature_verification_algorithms.supported_schemes()
+            }
+        }
+    }
+
+    fn test_ssl_context() -> SslContext {
+        SslContext::builder(SslMethod::tls_client())
+            .unwrap()
+            .build()
+    }
+
+    /*    fn test_tls_server_config() -> SslContext {
+        let CertifiedKey { cert, signing_key } =
+            rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).unwrap();
+        let cert = openssl::x509::X509::from_der(cert.der()).unwrap();
+        let mut builder = SslContext::builder(SslMethod::tls_server()).unwrap();
+        builder.cert_store().add_cert(cert).unwrap();
+        builder.set_verify_callback(openssl::ssl::SslVerifyMode::FAIL_IF_NO_PEER_CERT, |_ok, _store| {
+            true
+        });
+    }*/
+
+    fn turn_openssl_new(
+        transport: TransportType,
+        local_addr: SocketAddr,
+        remote_addr: SocketAddr,
+        credentials: TurnCredentials,
+    ) -> TurnClient {
+        TurnClientOpensslTls::allocate(
+            transport,
+            local_addr,
+            remote_addr,
+            credentials,
+            &[AddressFamily::IPV4],
+            test_ssl_context(),
+        )
+        .into()
+    }
+    /*
+    fn turn_server_openssl_new(listen_address: SocketAddr, realm: String) -> RustlsTurnServer {
+        RustlsTurnServer::new(listen_address, realm, server_config())
+    }
+
+    fn create_test() -> TurnTest<TurnClient, RustlsTurnServer> {
+        TurnTest::<TurnClient, RustlsTurnServer>::builder()
+            .build(turn_rustls_new, turn_server_rustls_new)
+    }
+
+    fn complete_io<A: TurnClientApi, S: TurnServerApi>(test: &mut TurnTest<A, S>, now: Instant) {
+        let mut handled = false;
+        loop {
+            test.client.poll(now);
+            test.server.poll(now);
+            if let Some(transmit) = test.client.poll_transmit(now) {
+                handled = true;
+                trace!("have transmit: {transmit:?}");
+                if let Some(transmit) = test.server.recv(transmit, now) {
+                    trace!("have transmit: {transmit:?}");
+                    test.client.recv(transmit.build(), now);
+                }
+            }
+            if let Some(transmit) = test.server.poll_transmit(now) {
+                handled = true;
+                trace!("have transmit: {transmit:?}");
+                test.client_recv(transmit, now);
+            }
+            if !handled {
+                break;
+            }
+            handled = false;
+        }
+    }
+
+    fn allocate_udp<A: TurnClientApi, S: TurnServerApi>(test: &mut TurnTest<A, S>, now: Instant) {
+        complete_io(test, now);
+        test.server.allocated_udp_socket(
+            TransportType::Tcp,
+            test.client.remote_addr(),
+            test.client.local_addr(),
+            AddressFamily::IPV4,
+            Ok(test.turn_alloc_addr),
+            now,
+        );
+        complete_io(test, now);
+        let event = test.client.poll_event().unwrap();
+        assert!(matches!(event, TurnEvent::AllocationCreated(_, _)));
+        assert_eq!(
+            test.client.relayed_addresses().next(),
+            Some((TransportType::Udp, test.turn_alloc_addr))
+        );
+    }
+
+    fn udp_permission<A: TurnClientApi, S: TurnServerApi>(test: &mut TurnTest<A, S>, now: Instant) {
+        test.client
+            .create_permission(TransportType::Udp, test.peer_addr.ip(), now)
+            .unwrap();
+        complete_io(test, now);
+
+        let event = test.client.poll_event().unwrap();
+        assert!(matches!(event, TurnEvent::PermissionCreated(_, _)));
+        let (transport, relayed) = test.client.relayed_addresses().next().unwrap();
+        assert!(test
+            .client
+            .permissions(transport, relayed)
+            .any(|perm_ip| perm_ip == test.peer_addr.ip()));
+        assert!(test.client.have_permission(transport, test.peer_addr.ip()));
+    }
+
+    fn delete_udp<A: TurnClientApi, S: TurnServerApi>(test: &mut TurnTest<A, S>, now: Instant) {
+        test.client.delete(now).unwrap();
+        complete_io(test, now);
+        assert_eq!(test.client.relayed_addresses().count(), 0);
+    }
+
+    fn channel_bind<A: TurnClientApi, S: TurnServerApi>(test: &mut TurnTest<A, S>, now: Instant) {
+        test.client
+            .bind_channel(TransportType::Udp, test.peer_addr, now)
+            .unwrap();
+        complete_io(test, now);
+
+        if let Some(event) = test.client.poll_event() {
+            assert!(matches!(event, TurnEvent::PermissionCreated(_, _)));
+        }
+        let (transport, relayed) = test.client.relayed_addresses().next().unwrap();
+        assert!(test
+            .client
+            .permissions(transport, relayed)
+            .any(|perm_ip| perm_ip == test.peer_addr.ip()));
+        assert!(test.client.have_permission(transport, test.peer_addr.ip()));
+    }
+
+    fn sendrecv_data<A: TurnClientApi, S: TurnServerApi>(test: &mut TurnTest<A, S>, now: Instant) {
+        // client to peer
+        let data = [4; 8];
+        let transmit = test
+            .client
+            .send_to(TransportType::Udp, test.peer_addr, data, now)
+            .unwrap()
+            .unwrap();
+        assert!(matches!(
+            transmit.data,
+            DelayedMessageOrChannelSend::Data(_)
+        ));
+        let transmit = transmit_send_build(transmit);
+        assert_eq!(transmit.transport, test.client.transport());
+        assert_eq!(transmit.from, test.client.local_addr());
+        assert_eq!(transmit.to, test.server.listen_address());
+        let transmit = test.server.recv(transmit, now).unwrap();
+        assert_eq!(transmit.transport, TransportType::Udp);
+        assert_eq!(transmit.from, test.turn_alloc_addr);
+        assert_eq!(transmit.to, test.peer_addr);
+
+        // peer to client
+        let sent_data = [5; 12];
+        let transmit = test
+            .server
+            .recv(
+                Transmit::new(
+                    sent_data,
+                    TransportType::Udp,
+                    test.peer_addr,
+                    test.turn_alloc_addr,
+                ),
+                now,
+            )
+            .unwrap();
+        assert_eq!(transmit.transport, test.client.transport());
+        assert_eq!(transmit.from, test.server.listen_address());
+        assert_eq!(transmit.to, test.client.local_addr());
+        let TurnRecvRet::PeerData(peer_data) = test.client.recv(transmit.build(), now) else {
+            unreachable!();
+        };
+        assert_eq!(peer_data.peer, test.peer_addr);
+        assert_eq!(peer_data.data(), sent_data);
+    }
+
+    #[test]
+    fn test_turn_rustls_allocate_udp_permission() {
+        let _log = crate::tests::test_init_log();
+        let now = Instant::ZERO;
+        let mut test = create_test();
+        allocate_udp(&mut test, now);
+        udp_permission(&mut test, now);
+        sendrecv_data(&mut test, now);
+    }
+
+    #[test]
+    fn test_turn_rustls_allocate_refresh() {
+        let _log = crate::tests::test_init_log();
+        let now = Instant::ZERO;
+        let mut test = create_test();
+        allocate_udp(&mut test, now);
+        let TurnPollRet::WaitUntil(expiry) = test.client.poll(now) else {
+            unreachable!();
+        };
+        assert!(now + Duration::from_secs(1000) < expiry);
+        // TODO: removing this (REFRESH handling) produces multiple messages in a single TCP
+        // transmit which the server currently does not like.
+        complete_io(&mut test, expiry);
+        udp_permission(&mut test, expiry);
+        sendrecv_data(&mut test, expiry);
+    }
+
+    #[test]
+    fn test_turn_rustls_allocate_delete() {
+        let _log = crate::tests::test_init_log();
+        let now = Instant::ZERO;
+        let mut test = create_test();
+        allocate_udp(&mut test, now);
+        delete_udp(&mut test, now);
+    }
+
+    #[test]
+    fn test_turn_rustls_allocate_bind_channel() {
+        let _log = crate::tests::test_init_log();
+        let now = Instant::ZERO;
+        let mut test = create_test();
+        allocate_udp(&mut test, now);
+        channel_bind(&mut test, now);
+        sendrecv_data(&mut test, now);
+    }
+
+    #[test]
+    fn test_turn_rustls_offpath_data() {
+        let _log = crate::tests::test_init_log();
+        let now = Instant::ZERO;
+        let mut test = create_test();
+        allocate_udp(&mut test, now);
+        udp_permission(&mut test, now);
+        let data = Message::builder(
+            MessageType::from_class_method(
+                turn_types::stun::message::MessageClass::Error,
+                CREATE_PERMISSION,
+            ),
+            TransactionId::generate(),
+            MessageWriteVec::new(),
+        )
+        .finish();
+        let transmit = Transmit::new(
+            data,
+            test.client.transport(),
+            test.turn_alloc_addr,
+            test.client.local_addr(),
+        );
+        assert!(matches!(
+            test.client.recv(transmit, now),
+            TurnRecvRet::Ignored(_)
+        ));
+    }*/
+}

--- a/turn-client-proto/src/rustls.rs
+++ b/turn-client-proto/src/rustls.rs
@@ -46,14 +46,14 @@ use turn_types::tcp::{IncomingTcp, StoredTcp, TurnTcpBuffer};
 
 /// A TURN client that communicates over TLS.
 #[derive(Debug)]
-pub struct TurnClientTls {
+pub struct TurnClientRustls {
     protocol: TurnClientProtocol,
     conn: Box<ClientConnection>,
     incoming_tcp_buffer: TurnTcpBuffer,
     closing: bool,
 }
 
-impl TurnClientTls {
+impl TurnClientRustls {
     /// Allocate an address on a TURN server to relay data to and from peers.
     pub fn allocate(
         local_addr: SocketAddr,
@@ -155,7 +155,7 @@ impl TurnClientTls {
     }
 }
 
-impl TurnClientApi for TurnClientTls {
+impl TurnClientApi for TurnClientRustls {
     fn transport(&self) -> TransportType {
         self.protocol.transport()
     }
@@ -546,7 +546,7 @@ mod tests {
         remote_addr: SocketAddr,
         credentials: TurnCredentials,
     ) -> TurnClient {
-        TurnClientTls::allocate(
+        TurnClientRustls::allocate(
             local_addr,
             remote_addr,
             credentials,

--- a/turn-server-proto/Cargo.toml
+++ b/turn-server-proto/Cargo.toml
@@ -12,9 +12,10 @@ repository.workspace = true
 rust-version.workspace = true
 
 [features]
-default = ["rustls", "std"]
+default = ["rustls", "std", "openssl"]
 rustls = ["dep:rustls", "std"]
 std = ["turn-types/std", "stun-proto/std", "thiserror/std", "rand/std"]
+openssl = ["dep:openssl", "std"]
 
 [dependencies]
 byteorder.workspace = true
@@ -23,6 +24,7 @@ thiserror.workspace = true
 tracing.workspace = true
 turn-types.workspace = true
 pnet_packet = { version = "0.35", default-features = false }
+openssl = { workspace = true, optional = true }
 rand = { version = "0.9", default-features = false, features = ["alloc", "os_rng"] }
 rustls = { workspace = true, optional = true }
 smallvec = "1"

--- a/turn-server-proto/src/lib.rs
+++ b/turn-server-proto/src/lib.rs
@@ -30,6 +30,9 @@ pub mod server;
 #[cfg(feature = "rustls")]
 pub mod rustls;
 
+#[cfg(feature = "openssl")]
+pub mod openssl;
+
 #[cfg(test)]
 mod tests {
     use tracing::subscriber::DefaultGuard;

--- a/turn-server-proto/src/openssl.rs
+++ b/turn-server-proto/src/openssl.rs
@@ -1,0 +1,434 @@
+// Copyright (C) 2025 Matthew Waters <matthew@centricular.com>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! A TURN server that can handle TLS client connections.
+
+use alloc::collections::VecDeque;
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::net::SocketAddr;
+use core::time::Duration;
+use std::io::{Read, Write};
+use turn_types::prelude::DelayedTransmitBuild;
+use turn_types::transmit::TransmitBuild;
+use turn_types::AddressFamily;
+
+use openssl::ssl::{HandshakeError, MidHandshakeSslStream, Ssl, SslContext, SslStream};
+use stun_proto::agent::Transmit;
+use stun_proto::Instant;
+use tracing::{info, trace, warn};
+use turn_types::stun::TransportType;
+
+use crate::api::{
+    DelayedMessageOrChannelSend, SocketAllocateError, TurnServerApi, TurnServerPollRet,
+};
+use crate::server::TurnServer;
+
+/// A TURN server that can handle TLS connections.
+#[derive(Debug)]
+pub struct OpensslTurnServer {
+    server: TurnServer,
+    ssl_context: SslContext,
+    connections: Vec<(SocketAddr, HandshakeState)>,
+}
+
+#[derive(Debug)]
+enum HandshakeState {
+    Init(Ssl, OsslBio),
+    Handshaking(MidHandshakeSslStream<OsslBio>),
+    Done(SslStream<OsslBio>),
+    Nothing,
+}
+
+impl HandshakeState {
+    fn complete(&mut self) -> Result<&mut SslStream<OsslBio>, std::io::Error> {
+        if let Self::Done(s) = self {
+            return Ok(s);
+        }
+        let taken = core::mem::replace(self, Self::Nothing);
+
+        let ret = match taken {
+            Self::Init(ssl, bio) => ssl.accept(bio),
+            Self::Handshaking(mid) => mid.handshake(),
+            Self::Done(_) | Self::Nothing => unreachable!(),
+        };
+
+        match ret {
+            Ok(s) => {
+                info!(
+                    "SSL handshake completed with version {} cipher: {:?}",
+                    s.ssl().version_str(),
+                    s.ssl().current_cipher()
+                );
+                *self = Self::Done(s);
+                Ok(self.complete()?)
+            }
+            Err(HandshakeError::WouldBlock(mid)) => {
+                *self = Self::Handshaking(mid);
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::WouldBlock,
+                    "Would Block",
+                ))
+            }
+            Err(HandshakeError::SetupFailure(e)) => {
+                warn!("Error during ssl setup: {e}");
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::ConnectionRefused,
+                    e,
+                ))
+            }
+            Err(HandshakeError::Failure(mid)) => {
+                warn!("Failure during ssl setup: {}", mid.error());
+                *self = Self::Handshaking(mid);
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::WouldBlock,
+                    "Would Block",
+                ))
+            }
+        }
+    }
+    fn inner_mut(&mut self) -> &mut OsslBio {
+        match self {
+            Self::Init(_ssl, stream) => stream,
+            Self::Handshaking(mid) => mid.get_mut(),
+            Self::Done(stream) => stream.get_mut(),
+            Self::Nothing => unreachable!(),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct OsslBio {
+    incoming: Vec<u8>,
+    outgoing: VecDeque<Vec<u8>>,
+}
+
+impl OsslBio {
+    fn push_incoming(&mut self, buf: &[u8]) {
+        self.incoming.extend_from_slice(buf)
+    }
+
+    fn pop_outgoing(&mut self) -> Option<Vec<u8>> {
+        self.outgoing.pop_front()
+    }
+}
+
+impl std::io::Write for OsslBio {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.outgoing.push_back(buf.to_vec());
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl std::io::Read for OsslBio {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let len = self.incoming.len();
+        let max = buf.len().min(len);
+
+        if len == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::WouldBlock,
+                "Would Block",
+            ));
+        }
+
+        buf[..max].copy_from_slice(&self.incoming[..max]);
+        if max == len {
+            self.incoming.truncate(0);
+        } else {
+            self.incoming.drain(..max);
+        }
+
+        Ok(max)
+    }
+}
+
+impl OpensslTurnServer {
+    /// Construct a now Turn server that can handle TLS connections.
+    pub fn new(
+        transport: TransportType,
+        listen_addr: SocketAddr,
+        realm: String,
+        ssl_context: SslContext,
+    ) -> Self {
+        Self {
+            server: TurnServer::new(transport, listen_addr, realm),
+            ssl_context,
+            connections: vec![],
+        }
+    }
+}
+
+impl TurnServerApi for OpensslTurnServer {
+    /// Add a user credentials that would be accepted by this [`TurnServer`].
+    fn add_user(&mut self, username: String, password: String) {
+        self.server.add_user(username, password)
+    }
+
+    /// The address that the [`TurnServer`] is listening on for incoming client connections.
+    fn listen_address(&self) -> SocketAddr {
+        self.server.listen_address()
+    }
+
+    /// Set the amount of time that a Nonce (used for authentication) will expire and a new Nonce
+    /// will need to be acquired by a client.
+    fn set_nonce_expiry_duration(&mut self, expiry_duration: Duration) {
+        self.server.set_nonce_expiry_duration(expiry_duration)
+    }
+
+    /// Provide received data to the [`TurnServer`].
+    ///
+    /// Any returned Transmit should be forwarded to the appropriate socket.
+    #[tracing::instrument(
+        name = "turn_server_openssl_recv",
+        skip(self, transmit, now),
+        fields(
+            from = ?transmit.from,
+            data_len = transmit.data.as_ref().len()
+        )
+    )]
+    fn recv<T: AsRef<[u8]> + core::fmt::Debug>(
+        &mut self,
+        transmit: Transmit<T>,
+        now: Instant,
+    ) -> Option<TransmitBuild<DelayedMessageOrChannelSend<T>>> {
+        let listen_address = self.listen_address();
+        if transmit.transport == TransportType::Tcp && transmit.to == listen_address {
+            trace!("receiving TLS data: {:x?}", transmit.data.as_ref());
+            // incoming client
+            let (client_addr, conn) = match self
+                .connections
+                .iter_mut()
+                .find(|(client_addr, _conn)| *client_addr == transmit.from)
+            {
+                Some((client_addr, conn)) => (*client_addr, conn),
+                None => {
+                    let len = self.connections.len();
+                    let ssl = Ssl::new(&self.ssl_context).expect("Cannot create ssl structure");
+                    self.connections
+                        .push((transmit.from, HandshakeState::Init(ssl, OsslBio::default())));
+                    info!("new connection from {}", transmit.from);
+                    let ret = &mut self.connections[len];
+                    (ret.0, &mut ret.1)
+                }
+            };
+            conn.inner_mut().push_incoming(transmit.data.as_ref());
+            let stream = match conn.complete() {
+                Ok(s) => s,
+                Err(e) => {
+                    if e.kind() != std::io::ErrorKind::WouldBlock {
+                        warn!("error accepting TLS: {e}");
+                    }
+                    return None;
+                }
+            };
+
+            let mut plaintext = vec![0; 2048];
+            let len = match stream.read(&mut plaintext) {
+                Ok(len) => len,
+                Err(e) => {
+                    if e.kind() != std::io::ErrorKind::WouldBlock {
+                        tracing::warn!("Error: {e}");
+                    }
+                    return None;
+                }
+            };
+            plaintext.resize(len, 0);
+
+            let transmit = self.server.recv(
+                Transmit::new(plaintext, transmit.transport, transmit.from, transmit.to),
+                now,
+            )?;
+
+            if transmit.transport == TransportType::Tcp
+                && transmit.from == listen_address
+                && transmit.to == client_addr
+            {
+                let plaintext = transmit.data.build();
+                stream.write_all(&plaintext).unwrap();
+                stream.get_mut().pop_outgoing().map(|data| {
+                    TransmitBuild::new(
+                        DelayedMessageOrChannelSend::Owned(data),
+                        TransportType::Tcp,
+                        listen_address,
+                        client_addr,
+                    )
+                })
+            } else {
+                let transmit = transmit.build();
+                Some(TransmitBuild::new(
+                    DelayedMessageOrChannelSend::Owned(transmit.data),
+                    transmit.transport,
+                    transmit.from,
+                    transmit.to,
+                ))
+            }
+        } else if let Some(transmit) = self.server.recv(transmit, now) {
+            // incoming allocated address
+            if transmit.transport == TransportType::Tcp && transmit.from == listen_address {
+                let Some((client_addr, conn)) = self
+                    .connections
+                    .iter_mut()
+                    .find(|(client_addr, _conn)| transmit.to == *client_addr)
+                else {
+                    return Some(transmit);
+                };
+
+                let plaintext = transmit.data.build();
+                let stream = match conn.complete() {
+                    Ok(s) => s,
+                    Err(e) => {
+                        if e.kind() != std::io::ErrorKind::WouldBlock {
+                            warn!("error accepting TLS: {e}");
+                        }
+                        return None;
+                    }
+                };
+                stream.write_all(&plaintext).unwrap();
+                stream.get_mut().pop_outgoing().map(|data| {
+                    TransmitBuild::new(
+                        DelayedMessageOrChannelSend::Owned(data),
+                        TransportType::Tcp,
+                        listen_address,
+                        *client_addr,
+                    )
+                })
+            } else {
+                Some(transmit)
+            }
+        } else {
+            None
+        }
+    }
+
+    fn recv_icmp<T: AsRef<[u8]>>(
+        &mut self,
+        family: AddressFamily,
+        bytes: T,
+        now: Instant,
+    ) -> Option<Transmit<Vec<u8>>> {
+        let transmit = self.server.recv_icmp(family, bytes, now)?;
+        // incoming allocated address
+        let listen_address = self.listen_address();
+        if transmit.transport == TransportType::Tcp && transmit.from == listen_address {
+            let Some((client_addr, conn)) = self
+                .connections
+                .iter_mut()
+                .find(|(client_addr, _conn)| transmit.to == *client_addr)
+            else {
+                return Some(transmit);
+            };
+            let stream = match conn.complete() {
+                Ok(s) => s,
+                Err(e) => {
+                    if e.kind() != std::io::ErrorKind::WouldBlock {
+                        warn!("error accepting TLS: {e}");
+                    }
+                    return None;
+                }
+            };
+            stream.write_all(&transmit.data).unwrap();
+            stream
+                .get_mut()
+                .pop_outgoing()
+                .map(|data| Transmit::new(data, TransportType::Tcp, listen_address, *client_addr))
+        } else {
+            Some(transmit)
+        }
+    }
+
+    /// Poll the [`TurnServer`] in order to make further progress.
+    ///
+    /// The returned value indicates what the caller should do.
+    fn poll(&mut self, now: Instant) -> TurnServerPollRet {
+        let protocol_ret = self.server.poll(now);
+        let mut have_pending = false;
+        for (_client_addr, conn) in self.connections.iter_mut() {
+            let stream = match conn.complete() {
+                Ok(s) => s,
+                Err(_) => continue,
+            };
+            if !stream.get_mut().outgoing.is_empty() {
+                have_pending = true;
+            }
+        }
+        if have_pending {
+            return TurnServerPollRet::WaitUntil(now);
+        }
+        protocol_ret
+    }
+
+    /// Poll for a new Transmit to send over a socket.
+    fn poll_transmit(&mut self, now: Instant) -> Option<Transmit<Vec<u8>>> {
+        let listen_address = self.listen_address();
+
+        for (client_addr, conn) in self.connections.iter_mut() {
+            if let Some(data) = conn.inner_mut().pop_outgoing() {
+                return Some(Transmit::new(
+                    data,
+                    TransportType::Tcp,
+                    listen_address,
+                    *client_addr,
+                ));
+            }
+        }
+
+        while let Some(transmit) = self.server.poll_transmit(now) {
+            let Some((client_addr, conn)) = self
+                .connections
+                .iter_mut()
+                .find(|(client_addr, _conn)| transmit.to == *client_addr)
+            else {
+                warn!("return transmit: {transmit:?}");
+                return Some(transmit);
+            };
+            let stream = match conn.complete() {
+                Ok(s) => s,
+                // FIXME: how to deal with early data
+                Err(_) => continue,
+            };
+            stream.write_all(&transmit.data).unwrap();
+
+            if let Some(data) = conn.inner_mut().pop_outgoing() {
+                return Some(Transmit::new(
+                    data,
+                    TransportType::Tcp,
+                    listen_address,
+                    *client_addr,
+                ));
+            }
+        }
+        None
+    }
+
+    /// Notify the [`TurnServer`] that a UDP socket has been allocated (or an error) in response to
+    /// [TurnServerPollRet::AllocateSocketUdp].
+    fn allocated_udp_socket(
+        &mut self,
+        transport: TransportType,
+        local_addr: SocketAddr,
+        remote_addr: SocketAddr,
+        family: AddressFamily,
+        socket_addr: Result<SocketAddr, SocketAllocateError>,
+        now: Instant,
+    ) {
+        self.server.allocated_udp_socket(
+            transport,
+            local_addr,
+            remote_addr,
+            family,
+            socket_addr,
+            now,
+        )
+    }
+}

--- a/turn-server-proto/src/server.rs
+++ b/turn-server-proto/src/server.rs
@@ -1469,6 +1469,7 @@ impl TurnServerApi for TurnServer {
         );
 
         if is_all_error && pending.pending_sockets.len() > 1 {
+            trace!("Returning insufficient capacity");
             // RFC8656 ADDITIONAL-ADDRESS-FAMILY path
             let error = ErrorCode::builder(ErrorCode::INSUFFICIENT_CAPACITY)
                 .build()


### PR DESCRIPTION
Adds support for DTLS connections to a TURN server which is part of RFC8656. Rustls does not currently support DTLS.