### PR TITLE
client: use the correct transport for received peer data with STUN DATA

### DIFF
--- a/turn-client-proto/src/api.rs
+++ b/turn-client-proto/src/api.rs
@@ -700,7 +700,7 @@ pub(crate) mod tests {
             }
         }
 
-        fn allocate(&mut self, now: Instant) {
+        pub(crate) fn allocate(&mut self, now: Instant) {
             // initial allocate
             let transmit = self.client.poll_transmit(now).unwrap();
             let msg = Message::from_bytes(&transmit.data).unwrap();
@@ -866,7 +866,7 @@ pub(crate) mod tests {
                 ))
         }
 
-        fn create_permission(&mut self, now: Instant) {
+        pub(crate) fn create_permission(&mut self, now: Instant) {
             self.client
                 .create_permission(self.allocation_transport, self.peer_addr.ip(), now)
                 .unwrap();

--- a/turn-client-proto/src/protocol.rs
+++ b/turn-client-proto/src/protocol.rs
@@ -846,15 +846,18 @@ impl TurnClientProtocol {
                     };
                     let peer_addr = peer_addr.addr(msg.transaction_id());
                     if let Some((offset, data)) = data {
-                        if allocations
-                            .iter()
-                            .all(|alloc| !alloc.have_permission(peer_addr.ip()))
-                        {
+                        let Some(allocation_transport) = allocations.iter().find_map(|alloc| {
+                            if alloc.have_permission(peer_addr.ip()) {
+                                Some(alloc.transport)
+                            } else {
+                                None
+                            }
+                        }) else {
                             return TurnProtocolRecv::Ignored;
-                        }
+                        };
                         TurnProtocolRecv::PeerData {
                             range: offset + 4..offset + 4 + data.data().len(),
-                            transport,
+                            transport: allocation_transport,
                             peer: peer_addr,
                         }
                     } else if let Some(icmp) = icmp {


### PR DESCRIPTION
Also add unit test.