### PR TITLE
client: use a dedicated TurnConfig struct for protocol level configuration

### DIFF
--- a/fuzz/fuzz_targets/helpers/test_client.rs
+++ b/fuzz/fuzz_targets/helpers/test_client.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use core::net::SocketAddr;
 use stun_types::TransportType;
-use turn_client_proto::api::{TurnClientApi, TurnEvent, TurnPollRet};
+use turn_client_proto::api::{TurnClientApi, TurnConfig, TurnEvent, TurnPollRet};
 use turn_client_proto::client::TurnClient;
 use turn_client_proto::stun::Instant;
 use turn_client_proto::udp::TurnClientUdp;
@@ -32,11 +32,12 @@ impl TestClient {
             credentials.username().to_string(),
             credentials.password().to_string(),
         );
+        let mut config = TurnConfig::new(credentials.clone());
+        config.add_address_family(AddressFamily::IPV6);
         let client = TurnClientUdp::allocate(
             client_addr,
             server_addr,
-            credentials.clone(),
-            &[AddressFamily::IPV4, AddressFamily::IPV6],
+            config,
         );
         let relayed_ipv4 = "10.0.0.2:2222".parse().unwrap();
         let relayed_ipv6 = "[fe80::1]:2222".parse().unwrap();

--- a/turn-client-proto/benches/sendrecv.rs
+++ b/turn-client-proto/benches/sendrecv.rs
@@ -15,12 +15,11 @@ use std::net::SocketAddr;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use stun_proto::agent::Transmit;
 use stun_proto::Instant;
-use turn_client_proto::api::{DelayedMessageOrChannelSend, TurnEvent, TurnRecvRet};
+use turn_client_proto::api::{DelayedMessageOrChannelSend, TurnConfig, TurnEvent, TurnRecvRet};
 use turn_client_proto::prelude::*;
 use turn_client_proto::udp::TurnClientUdp;
 use turn_server_proto::api::{TurnServerApi, TurnServerPollRet};
 use turn_server_proto::server::TurnServer;
-use turn_types::AddressFamily;
 use turn_types::{stun::TransportType, TurnCredentials};
 
 struct TurnTest<T: TurnClientApi> {
@@ -132,7 +131,8 @@ static SIZES: [usize; 3] = [32, 1024, 16000];
 fn bench_turn_client_sendrecv(c: &mut Criterion) {
     let mut test = TurnTest::new(
         |local_addr: SocketAddr, remote_addr: SocketAddr, credentials: TurnCredentials| {
-            TurnClientUdp::allocate(local_addr, remote_addr, credentials, &[AddressFamily::IPV4])
+            let config = TurnConfig::new(credentials);
+            TurnClientUdp::allocate(local_addr, remote_addr, config)
         },
     );
 
@@ -241,7 +241,8 @@ fn bench_turn_client_sendrecv(c: &mut Criterion) {
     let mut group = c.benchmark_group("Turn/Recv");
     let mut test = TurnTest::new(
         |local_addr: SocketAddr, remote_addr: SocketAddr, credentials: TurnCredentials| {
-            TurnClientUdp::allocate(local_addr, remote_addr, credentials, &[AddressFamily::IPV4])
+            let config = TurnConfig::new(credentials);
+            TurnClientUdp::allocate(local_addr, remote_addr, config)
         },
     );
     let now = Instant::ZERO;

--- a/turn-client-proto/examples/turn.rs
+++ b/turn-client-proto/examples/turn.rs
@@ -66,7 +66,7 @@
 use rustls::pki_types::ServerName;
 use rustls::ClientConfig;
 use rustls_platform_verifier::ConfigVerifierExt;
-use turn_client_proto::api::TcpConnectError;
+use turn_client_proto::api::{TcpConnectError, TurnConfig};
 use turn_client_proto::client::TurnClient;
 use turn_client_proto::openssl::TurnClientOpensslTls;
 use turn_client_proto::prelude::*;
@@ -243,13 +243,12 @@ impl ClientUdp {
     fn new(
         socket: UdpSocket,
         to: SocketAddr,
-        credentials: TurnCredentials,
-        allocation_families: &[AddressFamily],
+        config: TurnConfig,
         events_sender: SyncSender<TurnEvent>,
     ) -> Self {
         let base_instant = std::time::Instant::now();
         let local_addr = socket.local_addr().unwrap();
-        let client = TurnClientUdp::allocate(local_addr, to, credentials, allocation_families);
+        let client = TurnClientUdp::allocate(local_addr, to, config);
         let inner = Arc::new((Mutex::new(client.into()), Condvar::new()));
         let socket = Arc::new(socket);
 
@@ -266,8 +265,7 @@ impl ClientUdp {
     fn new_openssl(
         socket: UdpSocket,
         to: SocketAddr,
-        credentials: TurnCredentials,
-        allocation_families: &[AddressFamily],
+        config: TurnConfig,
         events_sender: SyncSender<TurnEvent>,
         insecure_tls: bool,
     ) -> Self {
@@ -286,9 +284,7 @@ impl ClientUdp {
             TransportType::Udp,
             local_addr,
             remote_addr,
-            credentials,
-            TransportType::Udp,
-            allocation_families,
+            config,
             ssl_context.build(),
         );
         let inner = Arc::new((Mutex::new(client.into()), Condvar::new()));
@@ -518,21 +514,13 @@ impl ClientTcp {
     fn new(
         socket: TcpStream,
         to: SocketAddr,
-        credentials: TurnCredentials,
-        allocation_transport: TransportType,
-        allocation_families: &[AddressFamily],
+        config: TurnConfig,
         events_sender: SyncSender<TurnEvent>,
     ) -> Self {
         let base_instant = std::time::Instant::now();
         let local_addr = socket.local_addr().unwrap();
         let remote_addr = to;
-        let client = TurnClientTcp::allocate(
-            local_addr,
-            remote_addr,
-            credentials,
-            allocation_transport,
-            allocation_families,
-        );
+        let client = TurnClientTcp::allocate(local_addr, remote_addr, config);
         let socket_clone = socket.try_clone().unwrap();
         let local_addr = socket.local_addr().unwrap();
         let send_sender = tcp_send_thread(socket);
@@ -557,9 +545,7 @@ impl ClientTcp {
     fn new_rustls(
         socket: TcpStream,
         to: SocketAddr,
-        credentials: TurnCredentials,
-        allocation_transport: TransportType,
-        allocation_families: &[AddressFamily],
+        config: TurnConfig,
         server_name: ServerName<'static>,
         events_sender: SyncSender<TurnEvent>,
         insecure_tls: bool,
@@ -567,7 +553,7 @@ impl ClientTcp {
         let base_instant = std::time::Instant::now();
         let local_addr = socket.local_addr().unwrap();
         let remote_addr = to;
-        let config = if insecure_tls {
+        let tls_config = if insecure_tls {
             ClientConfig::builder()
                 .dangerous()
                 .with_custom_certificate_verifier(Arc::new(danger::NoCertificateVerification::new(
@@ -580,11 +566,9 @@ impl ClientTcp {
         let client = TurnClientRustls::allocate(
             local_addr,
             remote_addr,
-            credentials,
-            allocation_transport,
-            allocation_families,
+            config,
             server_name,
-            Arc::new(config),
+            Arc::new(tls_config),
         );
         let socket_clone = socket.try_clone().unwrap();
         let local_addr = socket.local_addr().unwrap();
@@ -610,9 +594,7 @@ impl ClientTcp {
     fn new_openssl(
         socket: TcpStream,
         to: SocketAddr,
-        credentials: TurnCredentials,
-        allocation_transport: TransportType,
-        allocation_families: &[AddressFamily],
+        config: TurnConfig,
         events_sender: SyncSender<TurnEvent>,
         insecure_tls: bool,
     ) -> Self {
@@ -631,9 +613,7 @@ impl ClientTcp {
             TransportType::Tcp,
             local_addr,
             remote_addr,
-            credentials,
-            allocation_transport,
-            allocation_families,
+            config,
             ssl_context.build(),
         );
         let socket_clone = socket.try_clone().unwrap();
@@ -922,6 +902,13 @@ fn main() -> io::Result<()> {
         panic!("TURN-TCP allocations can only be created with a TCP based connection to the TURN server. Use `--transport tcp`.");
     }
 
+    let mut config = TurnConfig::new(credentials);
+    config.set_allocation_transport(cli.allocation_transport.into());
+    config.set_address_family(address_families[0]);
+    for family in &address_families[1..] {
+        config.add_address_family(*family);
+    }
+
     let client = match transport {
         TransportType::Udp => {
             let socket = if server.is_ipv4() {
@@ -940,8 +927,7 @@ fn main() -> io::Result<()> {
                         let client = ClientUdp::new_openssl(
                             socket,
                             server,
-                            credentials,
-                            &address_families,
+                            config,
                             events_sender,
                             cli.insecure_tls,
                         );
@@ -949,13 +935,7 @@ fn main() -> io::Result<()> {
                     }
                 }
             } else {
-                let client = ClientUdp::new(
-                    socket,
-                    server,
-                    credentials,
-                    &address_families,
-                    events_sender,
-                );
+                let client = ClientUdp::new(socket, server, config, events_sender);
                 Box::new(client) as Box<dyn Client<_>>
             }
         }
@@ -973,9 +953,7 @@ fn main() -> io::Result<()> {
                         let client = ClientTcp::new_rustls(
                             socket,
                             server,
-                            credentials,
-                            cli.allocation_transport.into(),
-                            &address_families,
+                            config,
                             server_name,
                             events_sender,
                             cli.insecure_tls,
@@ -986,9 +964,7 @@ fn main() -> io::Result<()> {
                         let client = ClientTcp::new_openssl(
                             socket,
                             server,
-                            credentials,
-                            cli.allocation_transport.into(),
-                            &address_families,
+                            config,
                             //server_name,
                             events_sender,
                             cli.insecure_tls,
@@ -997,14 +973,7 @@ fn main() -> io::Result<()> {
                     }
                 }
             } else {
-                let client = ClientTcp::new(
-                    socket,
-                    server,
-                    credentials,
-                    cli.allocation_transport.into(),
-                    &address_families,
-                    events_sender,
-                );
+                let client = ClientTcp::new(socket, server, config, events_sender);
                 Box::new(client) as Box<dyn Client<_>>
             }
         }

--- a/turn-client-proto/src/api.rs
+++ b/turn-client-proto/src/api.rs
@@ -24,7 +24,7 @@ use stun_proto::agent::Transmit;
 use stun_proto::types::data::Data;
 use stun_proto::types::TransportType;
 use stun_proto::Instant;
-use turn_types::AddressFamily;
+use turn_types::{AddressFamily, TurnCredentials};
 
 /// The public API of a TURN client.
 pub trait TurnClientApi: core::fmt::Debug + Send {
@@ -127,6 +127,118 @@ pub trait TurnClientApi: core::fmt::Debug + Send {
 
     /// A higher layer has encountered an error and this client is no longer usable.
     fn protocol_error(&mut self);
+}
+
+/// Configuration structure for handling TURN client configuration.
+///
+/// Holds the following information:
+///   - Long term credentials for connecting to a TURN server.
+///   - The [`TransportType`] of the requested allocation.
+///   - A list of [`AddressFamily`]s the allocation should be attempted to be created with.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TurnConfig {
+    allocation_transport: TransportType,
+    address_families: smallvec::SmallVec<[AddressFamily; 2]>,
+    credentials: TurnCredentials,
+}
+
+impl TurnConfig {
+    /// Construct a new [`TurnConfig`] with the provided credentials.
+    ///
+    /// By default a IPV4/UDP allocation is requested.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use turn_client_proto::api::TurnConfig;
+    /// # use turn_types::{AddressFamily, TransportType, TurnCredentials};
+    /// let credentials = TurnCredentials::new("user", "pass");
+    /// let config = TurnConfig::new(credentials.clone());
+    /// assert_eq!(config.credentials(), &credentials);
+    /// assert_eq!(config.allocation_transport(), TransportType::Udp);
+    /// assert_eq!(config.address_families(), &[AddressFamily::IPV4]);
+    /// ```
+    pub fn new(credentials: TurnCredentials) -> Self {
+        Self {
+            allocation_transport: TransportType::Udp,
+            address_families: smallvec::smallvec![AddressFamily::IPV4],
+            credentials,
+        }
+    }
+
+    /// Set the allocation transport requested.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use turn_client_proto::api::TurnConfig;
+    /// # use turn_types::{TransportType, TurnCredentials};
+    /// let credentials = TurnCredentials::new("user", "pass");
+    /// let mut config = TurnConfig::new(credentials.clone());
+    /// config.set_allocation_transport(TransportType::Tcp);
+    /// assert_eq!(config.allocation_transport(), TransportType::Tcp);
+    /// ```
+    pub fn set_allocation_transport(&mut self, allocation_transport: TransportType) {
+        self.allocation_transport = allocation_transport;
+    }
+
+    /// Retrieve the allocation transport requested.
+    pub fn allocation_transport(&self) -> TransportType {
+        self.allocation_transport
+    }
+
+    /// Add an [`AddressFamily`] that will be requested.
+    ///
+    /// Duplicate [`AddressFamily`]s are ignored.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use turn_client_proto::api::TurnConfig;
+    /// # use turn_types::{AddressFamily, TurnCredentials};
+    /// let credentials = TurnCredentials::new("user", "pass");
+    /// let mut config = TurnConfig::new(credentials.clone());
+    /// assert_eq!(config.address_families(), &[AddressFamily::IPV4]);
+    /// // Duplicate AddressFamily is ignored.
+    /// config.add_address_family(AddressFamily::IPV4);
+    /// assert_eq!(config.address_families(), &[AddressFamily::IPV4]);
+    /// config.add_address_family(AddressFamily::IPV6);
+    /// assert_eq!(config.address_families(), &[AddressFamily::IPV4, AddressFamily::IPV6]);
+    /// ```
+    pub fn add_address_family(&mut self, family: AddressFamily) {
+        if !self.address_families.contains(&family) {
+            self.address_families.push(family);
+        }
+    }
+
+    /// Set the [`AddressFamily`] that will be requested.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use turn_client_proto::api::TurnConfig;
+    /// # use turn_types::{AddressFamily, TurnCredentials};
+    /// let credentials = TurnCredentials::new("user", "pass");
+    /// let mut config = TurnConfig::new(credentials.clone());
+    /// assert_eq!(config.address_families(), &[AddressFamily::IPV4]);
+    /// config.set_address_family(AddressFamily::IPV4);
+    /// assert_eq!(config.address_families(), &[AddressFamily::IPV4]);
+    /// config.set_address_family(AddressFamily::IPV6);
+    /// assert_eq!(config.address_families(), &[AddressFamily::IPV6]);
+    /// ```
+    pub fn set_address_family(&mut self, family: AddressFamily) {
+        self.address_families = smallvec::smallvec![family];
+    }
+
+    /// Retrieve the [`AddressFamily`]s that are requested.
+    pub fn address_families(&self) -> &[AddressFamily] {
+        &self.address_families
+    }
+
+    /// Retrieve the [`TurnCredentials`] used for authenticating with the TURN server.
+    pub fn credentials(&self) -> &TurnCredentials {
+        &self.credentials
+    }
 }
 
 /// Return value from calling [poll](TurnClientApi::poll)().

--- a/turn-client-proto/src/lib.rs
+++ b/turn-client-proto/src/lib.rs
@@ -40,15 +40,16 @@
 //!
 //! ```
 //! use turn_client_proto::udp::TurnClientUdp;
+//! use turn_client_proto::api::TurnConfig;
 //! let turn_server_address = "127.0.0.1:3478".parse().unwrap();
 //! let local_address = "127.0.0.1:1000".parse().unwrap();
 //! let credentials = turn_types::TurnCredentials::new("username", "password");
+//! let config = TurnConfig::new(credentials);
 //!
 //! let client = TurnClientUdp::allocate(
 //!     local_address,
 //!     turn_server_address,
-//!     credentials,
-//!     &[turn_types::AddressFamily::IPV4],
+//!     config,
 //! );
 //! ```
 

--- a/turn-client-proto/src/openssl.rs
+++ b/turn-client-proto/src/openssl.rs
@@ -30,14 +30,11 @@ use stun_proto::Instant;
 
 use stun_proto::types::TransportType;
 
-use turn_types::AddressFamily;
-use turn_types::TurnCredentials;
-
 use tracing::{info, trace, warn};
 
 use crate::api::{
     DelayedMessageOrChannelSend, Socket5Tuple, TcpAllocateError, TcpConnectError, TransmitBuild,
-    TurnClientApi, TurnPeerData,
+    TurnClientApi, TurnConfig, TurnPeerData,
 };
 
 pub use crate::api::{
@@ -187,9 +184,7 @@ impl TurnClientOpensslTls {
         transport: TransportType,
         local_addr: SocketAddr,
         remote_addr: SocketAddr,
-        credentials: TurnCredentials,
-        allocation_transport: TransportType,
-        allocation_families: &[AddressFamily],
+        config: TurnConfig,
         ssl_context: SslContext,
     ) -> Self {
         let ssl = Ssl::new(&ssl_context).expect("Cannot create ssl structure");
@@ -197,23 +192,14 @@ impl TurnClientOpensslTls {
         Self {
             protocol: match transport {
                 TransportType::Udp => {
-                    if allocation_transport != TransportType::Udp {
+                    if config.allocation_transport() != TransportType::Udp {
                         panic!("Cannot create a TCP allocation with a UDP connection to the TURN server")
                     }
-                    TcpOrUdp::Udp(TurnClientUdp::allocate(
-                        local_addr,
-                        remote_addr,
-                        credentials,
-                        allocation_families,
-                    ))
+                    TcpOrUdp::Udp(TurnClientUdp::allocate(local_addr, remote_addr, config))
                 }
-                TransportType::Tcp => TcpOrUdp::Tcp(TurnClientTcp::allocate(
-                    local_addr,
-                    remote_addr,
-                    credentials,
-                    allocation_transport,
-                    allocation_families,
-                )),
+                TransportType::Tcp => {
+                    TcpOrUdp::Tcp(TurnClientTcp::allocate(local_addr, remote_addr, config))
+                }
             },
             ssl_context,
             sockets: vec![Socket {
@@ -639,6 +625,7 @@ mod tests {
     use openssl::ssl::SslMethod;
     use tracing::debug;
     use turn_server_proto::openssl::OpensslTurnServer;
+    use turn_types::{AddressFamily, TurnCredentials};
 
     use crate::api::tests::{transmit_send_build, TurnTest};
     use crate::client::TurnClient;
@@ -691,16 +678,13 @@ mod tests {
         transport: TransportType,
         local_addr: SocketAddr,
         remote_addr: SocketAddr,
-        credentials: TurnCredentials,
-        allocation_transport: TransportType,
+        config: TurnConfig,
     ) -> TurnClient {
         TurnClientOpensslTls::allocate(
             transport,
             local_addr,
             remote_addr,
-            credentials,
-            allocation_transport,
-            &[AddressFamily::IPV4],
+            config,
             test_ssl_context(transport),
         )
         .into()
@@ -712,13 +696,9 @@ mod tests {
         credentials: TurnCredentials,
         allocation_transport: TransportType,
     ) -> TurnClient {
-        turn_openssl_new(
-            TransportType::Tcp,
-            local_addr,
-            remote_addr,
-            credentials,
-            allocation_transport,
-        )
+        let mut config = TurnConfig::new(credentials);
+        config.set_allocation_transport(allocation_transport);
+        turn_openssl_new(TransportType::Tcp, local_addr, remote_addr, config)
     }
 
     fn turn_udp_openssl_new(
@@ -727,13 +707,9 @@ mod tests {
         credentials: TurnCredentials,
         allocation_transport: TransportType,
     ) -> TurnClient {
-        turn_openssl_new(
-            TransportType::Udp,
-            local_addr,
-            remote_addr,
-            credentials,
-            allocation_transport,
-        )
+        let mut config = TurnConfig::new(credentials);
+        config.set_allocation_transport(allocation_transport);
+        turn_openssl_new(TransportType::Udp, local_addr, remote_addr, config)
     }
 
     fn turn_server_openssl_new(

--- a/turn-client-proto/src/protocol.rs
+++ b/turn-client-proto/src/protocol.rs
@@ -42,7 +42,7 @@ use turn_types::AddressFamily;
 use crate::api::{
     BindChannelError, CreatePermissionError, DataRangeOrOwned, DelayedMessageOrChannelSend,
     DeleteError, SendError, Socket5Tuple, TcpAllocateError, TcpConnectError, TransmitBuild,
-    TurnEvent, TurnPeerData, TurnPollRet, TurnRecvRet,
+    TurnConfig, TurnEvent, TurnPeerData, TurnPollRet, TurnRecvRet,
 };
 use crate::tcp::ensure_data_owned;
 
@@ -88,13 +88,11 @@ struct PendingTransmit {
 }
 
 impl TurnClientProtocol {
-    pub(crate) fn new(
-        stun_agent: StunAgent,
-        stun_auth: LongTermClientAuth,
-        allocation_transport: TransportType,
-        address_families: &[AddressFamily],
-    ) -> Self {
+    pub(crate) fn new(stun_agent: StunAgent, config: TurnConfig) -> Self {
         turn_types::debug_init();
+        let mut stun_auth = LongTermClientAuth::new();
+        stun_auth.set_credentials(config.credentials().clone().into());
+        let address_families = config.address_families();
         let families = address_families.iter().cloned().fold(
             smallvec::SmallVec::with_capacity(address_families.len()),
             |mut ret, fam| {
@@ -107,13 +105,13 @@ impl TurnClientProtocol {
         if families.is_empty() {
             panic!("Incorrect number of address families");
         }
-        if allocation_transport == TransportType::Tcp
+        if config.allocation_transport() == TransportType::Tcp
             && stun_agent.transport() != TransportType::Tcp
         {
             panic!("Cannot create TCP allocation without a TCP client connection");
         }
         Self {
-            allocation_transport,
+            allocation_transport: config.allocation_transport(),
             families,
             stun_agent,
             stun_auth,
@@ -2718,9 +2716,13 @@ mod tests {
         let stun_agent = StunAgent::builder(client_transport, local_addr)
             .remote_addr(remote_addr)
             .build();
-        let mut stun_auth = LongTermClientAuth::new();
-        stun_auth.set_credentials(credentials.into());
-        let client = TurnClientProtocol::new(stun_agent, stun_auth, allocation_transport, families);
+        let mut config = TurnConfig::new(credentials);
+        config.set_allocation_transport(allocation_transport);
+        config.set_address_family(families[0]);
+        for family in &families[1..] {
+            config.add_address_family(*family);
+        }
+        let client = TurnClientProtocol::new(stun_agent, config);
         assert_eq!(client.transport(), client_transport);
         assert_eq!(client.local_addr(), local_addr);
         assert_eq!(client.remote_addr(), remote_addr);

--- a/turn-client-proto/src/rustls.rs
+++ b/turn-client-proto/src/rustls.rs
@@ -28,14 +28,11 @@ use stun_proto::Instant;
 
 use stun_proto::types::TransportType;
 
-use turn_types::AddressFamily;
-use turn_types::TurnCredentials;
-
 use tracing::{debug, trace, warn};
 
 use crate::api::{
     DelayedMessageOrChannelSend, Socket5Tuple, TcpAllocateError, TcpConnectError, TransmitBuild,
-    TurnClientApi, TurnPeerData,
+    TurnClientApi, TurnConfig, TurnPeerData,
 };
 
 pub use crate::api::{
@@ -48,7 +45,7 @@ use crate::tcp::TurnClientTcp;
 #[derive(Debug)]
 pub struct TurnClientRustls {
     protocol: TurnClientTcp,
-    config: Arc<ClientConfig>,
+    tls_config: Arc<ClientConfig>,
     server_name: ServerName<'static>,
     pending_allocates: Vec<(u32, Socket5Tuple, SocketAddr)>,
     sockets: Vec<Socket>,
@@ -69,28 +66,20 @@ impl TurnClientRustls {
     pub fn allocate(
         local_addr: SocketAddr,
         remote_addr: SocketAddr,
-        credentials: TurnCredentials,
-        allocation_transport: TransportType,
-        allocation_families: &[AddressFamily],
+        config: TurnConfig,
         server_name: ServerName<'static>,
-        config: Arc<ClientConfig>,
+        tls_config: Arc<ClientConfig>,
     ) -> Self {
         Self {
-            protocol: TurnClientTcp::allocate(
-                local_addr,
-                remote_addr,
-                credentials,
-                allocation_transport,
-                allocation_families,
-            ),
+            protocol: TurnClientTcp::allocate(local_addr, remote_addr, config),
             sockets: vec![Socket {
                 local_addr,
                 remote_addr,
-                tls: ClientConnection::new(config.clone(), server_name.clone()).unwrap(),
+                tls: ClientConnection::new(tls_config.clone(), server_name.clone()).unwrap(),
                 local_closed: false,
                 peer_closed: false,
             }],
-            config,
+            tls_config,
             server_name,
             pending_allocates: vec![],
         }
@@ -348,7 +337,7 @@ impl TurnClientApi for TurnClientRustls {
                 self.sockets.push(Socket {
                     local_addr,
                     remote_addr: self.remote_addr(),
-                    tls: ClientConnection::new(self.config.clone(), self.server_name.clone())
+                    tls: ClientConnection::new(self.tls_config.clone(), self.server_name.clone())
                         .unwrap(),
                     local_closed: false,
                     peer_closed: false,
@@ -535,6 +524,7 @@ mod tests {
     use alloc::borrow::ToOwned;
     use alloc::string::{String, ToString};
     use core::time::Duration;
+    use turn_types::{AddressFamily, TurnCredentials};
 
     use crate::api::tests::{transmit_send_build, TurnTest};
     use crate::client::TurnClient;
@@ -646,12 +636,12 @@ mod tests {
         credentials: TurnCredentials,
         allocation_transport: TransportType,
     ) -> TurnClient {
+        let mut config = TurnConfig::new(credentials);
+        config.set_allocation_transport(allocation_transport);
         TurnClientRustls::allocate(
             local_addr,
             remote_addr,
-            credentials,
-            allocation_transport,
-            &[AddressFamily::IPV4],
+            config,
             remote_addr.ip().into(),
             client_config(),
         )

--- a/turn-client-proto/src/tcp.rs
+++ b/turn-client-proto/src/tcp.rs
@@ -16,7 +16,6 @@ use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
 use core::net::{IpAddr, SocketAddr};
 use core::ops::Range;
-use stun_proto::auth::LongTermClientAuth;
 use turn_types::stun::message::Message;
 
 use stun_proto::agent::{StunAgent, Transmit};
@@ -26,14 +25,12 @@ use stun_proto::Instant;
 
 use turn_types::channel::ChannelData;
 use turn_types::tcp::{IncomingTcp, StoredTcp, TurnTcpBuffer};
-use turn_types::AddressFamily;
-use turn_types::TurnCredentials;
 
 use tracing::{trace, warn};
 
 use crate::api::{
     DataRangeOrOwned, DelayedMessageOrChannelSend, Socket5Tuple, TcpAllocateError, TcpConnectError,
-    TransmitBuild, TurnClientApi, TurnPeerData,
+    TransmitBuild, TurnClientApi, TurnConfig, TurnPeerData,
 };
 use crate::protocol::{TurnClientProtocol, TurnProtocolChannelRecv, TurnProtocolRecv};
 
@@ -65,49 +62,40 @@ impl TurnClientTcp {
     ///
     /// # Examples
     /// ```
-    /// # use turn_types::{AddressFamily, TurnCredentials};
+    /// # use turn_types::TurnCredentials;
     /// # use turn_client_proto::prelude::*;
     /// # use turn_client_proto::tcp::TurnClientTcp;
+    /// # use turn_client_proto::api::TurnConfig;
     /// # use stun_proto::types::TransportType;
     /// let credentials = TurnCredentials::new("tuser", "tpass");
+    /// let mut config = TurnConfig::new(credentials);
+    /// // The transport protocol of the allocation on the TURN server.
+    /// config.set_allocation_transport(TransportType::Udp);
     /// let local_addr = "192.168.0.1:4000".parse().unwrap();
     /// let remote_addr = "10.0.0.1:3478".parse().unwrap();
     /// let client = TurnClientTcp::allocate(
     ///     local_addr,
     ///     remote_addr,
-    ///     credentials,
-    ///     // The transport protocol of the allocation on the TURN server.
-    ///     TransportType::Udp,
-    ///     &[AddressFamily::IPV4],
+    ///     config,
     /// );
     /// assert_eq!(client.transport(), TransportType::Tcp);
     /// assert_eq!(client.local_addr(), local_addr);
     /// assert_eq!(client.remote_addr(), remote_addr);
     /// ```
     #[tracing::instrument(
-        name = "turn_client_allocate"
-        skip(credentials)
+        name = "turn_client_tcp_allocate"
+        skip(config),
+        fields(
+            allocation_transport = %config.allocation_transport(),
+        )
     )]
-    pub fn allocate(
-        local_addr: SocketAddr,
-        remote_addr: SocketAddr,
-        credentials: TurnCredentials,
-        allocation_transport: TransportType,
-        allocation_families: &[AddressFamily],
-    ) -> Self {
+    pub fn allocate(local_addr: SocketAddr, remote_addr: SocketAddr, config: TurnConfig) -> Self {
         let stun_agent = StunAgent::builder(TransportType::Tcp, local_addr)
             .remote_addr(remote_addr)
             .build();
-        let mut stun_auth = LongTermClientAuth::new();
-        stun_auth.set_credentials(credentials.into());
 
         Self {
-            protocol: TurnClientProtocol::new(
-                stun_agent,
-                stun_auth,
-                allocation_transport,
-                allocation_families,
-            ),
+            protocol: TurnClientProtocol::new(stun_agent, config),
             incoming_tcp_buffers: BTreeMap::from([(
                 (local_addr, remote_addr),
                 TcpBuffer::Control(TurnTcpBuffer::new()),
@@ -540,6 +528,7 @@ mod tests {
     use turn_server_proto::server::TurnServer;
 
     use alloc::string::String;
+    use turn_types::TurnCredentials;
 
     use crate::{
         api::tests::{
@@ -559,14 +548,9 @@ mod tests {
         credentials: TurnCredentials,
         allocation_transport: TransportType,
     ) -> TurnClient {
-        TurnClientTcp::allocate(
-            local_addr,
-            remote_addr,
-            credentials,
-            allocation_transport,
-            &[AddressFamily::IPV4],
-        )
-        .into()
+        let mut config = TurnConfig::new(credentials);
+        config.set_allocation_transport(allocation_transport);
+        TurnClientTcp::allocate(local_addr, remote_addr, config).into()
     }
 
     fn turn_server_tcp_new(listen_addr: SocketAddr, realm: String) -> TurnServer {

--- a/turn-client-proto/src/udp.rs
+++ b/turn-client-proto/src/udp.rs
@@ -14,7 +14,6 @@
 
 use alloc::vec::Vec;
 use core::net::{IpAddr, SocketAddr};
-use stun_proto::auth::LongTermClientAuth;
 
 use stun_proto::agent::{StunAgent, Transmit};
 use stun_proto::types::data::Data;
@@ -24,14 +23,12 @@ use stun_proto::types::TransportType;
 
 use turn_types::channel::ChannelData;
 use turn_types::stun::message::Message;
-use turn_types::AddressFamily;
-use turn_types::TurnCredentials;
 
 use tracing::{trace, warn};
 
 use crate::api::{
     DataRangeOrOwned, DelayedMessageOrChannelSend, Socket5Tuple, TcpAllocateError, TcpConnectError,
-    TransmitBuild, TurnClientApi, TurnPeerData,
+    TransmitBuild, TurnClientApi, TurnConfig, TurnPeerData,
 };
 use crate::protocol::{TurnClientProtocol, TurnProtocolChannelRecv};
 
@@ -51,19 +48,19 @@ impl TurnClientUdp {
     ///
     /// # Examples
     /// ```
-    /// # use turn_types::{AddressFamily, TurnCredentials};
+    /// # use turn_types::TurnCredentials;
     /// # use turn_client_proto::prelude::*;
     /// # use turn_client_proto::udp::TurnClientUdp;
-    /// # use stun_proto::types::TransportType;
+    /// # use turn_client_proto::api::TurnConfig;
+    /// # use turn_types::TransportType;
     /// let credentials = TurnCredentials::new("tuser", "tpass");
-    /// let transport = TransportType::Udp;
+    /// let config = TurnConfig::new(credentials.clone());
     /// let local_addr = "192.168.0.1:4000".parse().unwrap();
     /// let remote_addr = "10.0.0.1:3478".parse().unwrap();
     /// let client = TurnClientUdp::allocate(
     ///     local_addr,
     ///     remote_addr,
-    ///     credentials,
-    ///     &[AddressFamily::IPV4],
+    ///     config,
     /// );
     /// assert_eq!(client.transport(), TransportType::Udp);
     /// assert_eq!(client.local_addr(), local_addr);
@@ -71,27 +68,19 @@ impl TurnClientUdp {
     /// ```
     #[tracing::instrument(
         name = "turn_client_allocate"
-        skip(credentials)
+        skip(config),
+        fields(allocation_transport = %config.allocation_transport(),)
     )]
-    pub fn allocate(
-        local_addr: SocketAddr,
-        remote_addr: SocketAddr,
-        credentials: TurnCredentials,
-        allocation_families: &[AddressFamily],
-    ) -> Self {
+    pub fn allocate(local_addr: SocketAddr, remote_addr: SocketAddr, config: TurnConfig) -> Self {
         let stun_agent = StunAgent::builder(TransportType::Udp, local_addr)
             .remote_addr(remote_addr)
             .build();
-        let mut stun_auth = LongTermClientAuth::new();
-        stun_auth.set_credentials(credentials.into());
+        if config.allocation_transport() != TransportType::Udp {
+            panic!("Attempt made to create a UDP TURN client without a UDP allocation");
+        }
 
         Self {
-            protocol: TurnClientProtocol::new(
-                stun_agent,
-                stun_auth,
-                TransportType::Udp,
-                allocation_families,
-            ),
+            protocol: TurnClientProtocol::new(stun_agent, config),
         }
     }
 }
@@ -249,6 +238,7 @@ impl TurnClientApi for TurnClientUdp {
 pub(crate) mod tests {
     use alloc::string::String;
     use turn_server_proto::server::TurnServer;
+    use turn_types::TurnCredentials;
 
     use super::*;
 
@@ -270,7 +260,9 @@ pub(crate) mod tests {
         allocation_transport: TransportType,
     ) -> TurnClient {
         assert_eq!(allocation_transport, TransportType::Udp);
-        TurnClientUdp::allocate(local_addr, remote_addr, credentials, &[AddressFamily::IPV4]).into()
+        let mut config = TurnConfig::new(credentials);
+        config.set_allocation_transport(allocation_transport);
+        TurnClientUdp::allocate(local_addr, remote_addr, config).into()
     }
 
     fn turn_server_udp_new(listen_address: SocketAddr, realm: String) -> TurnServer {

--- a/turn-server-proto/benches/sendrecv.rs
+++ b/turn-server-proto/benches/sendrecv.rs
@@ -17,12 +17,11 @@ use turn_types::stun::message::Message;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use stun_proto::agent::Transmit;
 use stun_proto::Instant;
-use turn_client_proto::api::{TurnEvent, TurnRecvRet};
+use turn_client_proto::api::{TurnConfig, TurnEvent, TurnRecvRet};
 use turn_client_proto::prelude::*;
 use turn_client_proto::udp::TurnClientUdp;
 use turn_server_proto::api::{TurnServerApi, TurnServerPollRet};
 use turn_server_proto::server::TurnServer;
-use turn_types::AddressFamily;
 use turn_types::{stun::TransportType, TurnCredentials};
 
 struct TurnTest<T: TurnClientApi> {
@@ -136,7 +135,8 @@ static SIZES: [usize; 3] = [32, 1024, 16000];
 fn bench_turn_server_sendrecv(c: &mut Criterion) {
     let mut test = TurnTest::new(
         |local_addr: SocketAddr, remote_addr: SocketAddr, credentials: TurnCredentials| {
-            TurnClientUdp::allocate(local_addr, remote_addr, credentials, &[AddressFamily::IPV4])
+            let config = TurnConfig::new(credentials);
+            TurnClientUdp::allocate(local_addr, remote_addr, config)
         },
     );
     let now = Instant::ZERO;
@@ -168,12 +168,8 @@ fn bench_turn_server_sendrecv(c: &mut Criterion) {
                     |local_addr: SocketAddr,
                      remote_addr: SocketAddr,
                      credentials: TurnCredentials| {
-                        TurnClientUdp::allocate(
-                            local_addr,
-                            remote_addr,
-                            credentials,
-                            &[AddressFamily::IPV4],
-                        )
+                        let config = TurnConfig::new(credentials);
+                        TurnClientUdp::allocate(local_addr, remote_addr, config)
                     },
                 );
                 let transmit = test.client.poll_transmit(now).unwrap();
@@ -216,12 +212,8 @@ fn bench_turn_server_sendrecv(c: &mut Criterion) {
                     |local_addr: SocketAddr,
                      remote_addr: SocketAddr,
                      credentials: TurnCredentials| {
-                        TurnClientUdp::allocate(
-                            local_addr,
-                            remote_addr,
-                            credentials,
-                            &[AddressFamily::IPV4],
-                        )
+                        let config = TurnConfig::new(credentials);
+                        TurnClientUdp::allocate(local_addr, remote_addr, config)
                     },
                 );
                 let transmit = test.client.poll_transmit(now).unwrap();
@@ -264,12 +256,8 @@ fn bench_turn_server_sendrecv(c: &mut Criterion) {
                     |local_addr: SocketAddr,
                      remote_addr: SocketAddr,
                      credentials: TurnCredentials| {
-                        TurnClientUdp::allocate(
-                            local_addr,
-                            remote_addr,
-                            credentials,
-                            &[AddressFamily::IPV4],
-                        )
+                        let config = TurnConfig::new(credentials);
+                        TurnClientUdp::allocate(local_addr, remote_addr, config)
                     },
                 );
                 test.allocate(now);
@@ -294,12 +282,8 @@ fn bench_turn_server_sendrecv(c: &mut Criterion) {
                     |local_addr: SocketAddr,
                      remote_addr: SocketAddr,
                      credentials: TurnCredentials| {
-                        TurnClientUdp::allocate(
-                            local_addr,
-                            remote_addr,
-                            credentials,
-                            &[AddressFamily::IPV4],
-                        )
+                        let config = TurnConfig::new(credentials);
+                        TurnClientUdp::allocate(local_addr, remote_addr, config)
                     },
                 );
                 test.allocate(now);
@@ -321,7 +305,8 @@ fn bench_turn_server_sendrecv(c: &mut Criterion) {
     let mut group = c.benchmark_group("Send");
     let mut test = TurnTest::new(
         |local_addr: SocketAddr, remote_addr: SocketAddr, credentials: TurnCredentials| {
-            TurnClientUdp::allocate(local_addr, remote_addr, credentials, &[AddressFamily::IPV4])
+            let config = TurnConfig::new(credentials);
+            TurnClientUdp::allocate(local_addr, remote_addr, config)
         },
     );
     let now = Instant::ZERO;
@@ -415,7 +400,8 @@ fn bench_turn_server_sendrecv(c: &mut Criterion) {
     let mut group = c.benchmark_group("Recv");
     let mut test = TurnTest::new(
         |local_addr: SocketAddr, remote_addr: SocketAddr, credentials: TurnCredentials| {
-            TurnClientUdp::allocate(local_addr, remote_addr, credentials, &[AddressFamily::IPV4])
+            let config = TurnConfig::new(credentials);
+            TurnClientUdp::allocate(local_addr, remote_addr, config)
         },
     );
     let now = Instant::ZERO;

--- a/turn-types/src/lib.rs
+++ b/turn-types/src/lib.rs
@@ -54,7 +54,7 @@ pub mod prelude {
 use alloc::borrow::ToOwned;
 use alloc::string::{String, ToString};
 use stun_types::message::{LongTermCredentials, LongTermKeyCredentials};
-pub use stun_types::AddressFamily;
+pub use stun_types::{AddressFamily, TransportType};
 
 /// Initialize some debugging functionality of the library.
 ///
@@ -66,7 +66,7 @@ pub fn debug_init() {
 }
 
 /// Credentials used for a TURN user.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TurnCredentials {
     username: String,
     password: String,


### PR DESCRIPTION
Allows easier backwards compatibility changes to the TURN configuration.